### PR TITLE
Check refresh token expiry based on config (default: false)

### DIFF
--- a/src/main/java/com/uid2/operator/Main.java
+++ b/src/main/java/com/uid2/operator/Main.java
@@ -223,7 +223,7 @@ public class Main {
 
     private void run() throws Exception {
         Supplier<Verticle> operatorVerticleSupplier = () -> {
-            return new UIDOperatorVerticle(clientKeyProvider, keyStore, keyAclProvider, saltProvider, optOutStore, Clock.systemUTC());
+            return new UIDOperatorVerticle(config, clientKeyProvider, keyStore, keyAclProvider, saltProvider, optOutStore, Clock.systemUTC());
         };
 
         DeploymentOptions options = new DeploymentOptions();

--- a/src/test/java/com/uid2/operator/UIDOperatorServiceTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorServiceTest.java
@@ -33,6 +33,7 @@ import com.uid2.operator.store.MockOptOutStore;
 import com.uid2.shared.store.RotatingKeyStore;
 import com.uid2.shared.store.RotatingSaltProvider;
 import com.uid2.shared.cloud.EmbeddedResourceStorage;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -62,7 +63,11 @@ public class UIDOperatorServiceTest {
 
         MockOptOutStore optOutStore = new MockOptOutStore();
 
-        final UIDOperatorService idService = new UIDOperatorService(keyStore,
+        final JsonObject config = new JsonObject();
+
+        final UIDOperatorService idService = new UIDOperatorService(
+            config,
+            keyStore,
             optOutStore,
             saltProvider,
             new EncryptedTokenEncoder(keyStore),

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -93,7 +93,10 @@ public class UIDOperatorVerticleTest {
         when(saltProvider.getSnapshot(any())).thenReturn(saltProviderSnapshot);
         when(clock.instant()).thenAnswer(i -> Instant.now());
 
-        UIDOperatorVerticle verticle = new UIDOperatorVerticle(clientKeyProvider, keyStore, keyAclProvider, saltProvider, optOutStore, clock);
+        final JsonObject config = new JsonObject();
+        config.put("check_refresh_token_expiry", true);
+
+        UIDOperatorVerticle verticle = new UIDOperatorVerticle(config, clientKeyProvider, keyStore, keyAclProvider, saltProvider, optOutStore, clock);
         vertx.deployVerticle(verticle, testContext.succeeding(id -> testContext.completeNow()));
     }
 


### PR DESCRIPTION
This will allow producing refresh tokens with sensible expiry before enforcing the check. Temporarily configurable for dev purposes: config will be eventually removed.