### PR TITLE
Fixes for JS SDK v1 disconnect method

### DIFF
--- a/js/uid2-sdk-1.0.0/async.test.js
+++ b/js/uid2-sdk-1.0.0/async.test.js
@@ -156,6 +156,14 @@ describe('when getAdvertisingTokenAsync is called after init completed', () => {
       return expect(uid2.getAdvertisingTokenAsync()).rejects.toBeInstanceOf(Error);
     });
   });
+
+  describe('when disconnect() has been called', () => {
+    it('it should reject promise', () => {
+      uid2.init({ callback: callback, identity: makeIdentity() });
+      uid2.disconnect();
+      return expect(uid2.getAdvertisingTokenAsync()).rejects.toBeInstanceOf(Error);
+    });
+  });
 });
 
 describe('when getAdvertisingTokenAsync is called before refresh on init completes', () => {
@@ -179,6 +187,21 @@ describe('when getAdvertisingTokenAsync is called before refresh on init complet
       xhrMock.responseText = JSON.stringify({ status: 'success', body: updatedIdentity });
       xhrMock.onreadystatechange(new Event(''));
       return expect(p).resolves.toBe(updatedIdentity.advertising_token);
+    });
+  });
+
+  describe('when disconnect() has been called', () => {
+    it('it should reject promise', () => {
+      const p = uid2.getAdvertisingTokenAsync();
+      uid2.disconnect();
+      return expect(p).rejects.toBeInstanceOf(Error);
+    });
+  });
+
+  describe('when promise obtained after disconnect', () => {
+    it('it should reject promise', () => {
+      uid2.disconnect();
+      return expect(uid2.getAdvertisingTokenAsync()).rejects.toBeInstanceOf(Error);
     });
   });
 });

--- a/js/uid2-sdk-1.0.0/basic.test.js
+++ b/js/uid2-sdk-1.0.0/basic.test.js
@@ -735,8 +735,18 @@ describe('disconnect()', () => {
     expect(xhrMock.send).toHaveBeenCalledTimes(1);
     expect(xhrMock.abort).toHaveBeenCalledTimes(1);
   });
+  it('should not invoke callback after aborting refresh token request', () => {
+    uid2.init({ callback: callback, identity: makeIdentity({ refresh_from: Date.now() - 100000 }) });
+    uid2.disconnect();
+    expect(callback).not.toHaveBeenCalled();
+  });
   it('should prevent subsequent calls to init()', () => {
     uid2.disconnect();
     expect(() => uid2.init({ callback: () => {} })).toThrow();
+  });
+  it('should switch to unavailable state', () => {
+    uid2.init({ callback: callback, identity: makeIdentity() });
+    uid2.disconnect();
+    expect(uid2).toBeInUnavailableState();
   });
 });

--- a/static/js/uid2-sdk-1.0.0.js
+++ b/static/js/uid2-sdk-1.0.0.js
@@ -90,6 +90,12 @@ class UID2 {
         this.disconnect = () => {
             this.abort();
             removeCookie(UID2.COOKIE_NAME);
+            _identity = undefined;
+            _lastStatus = UID2.IdentityStatus.INVALID;
+
+            const promises = _promises;
+            _promises = [];
+            promises.forEach(p => p.reject(new Error("disconnect()")));
         };
         this.abort = () => {
             _initCalled = true;


### PR DESCRIPTION
- reset the identity state to unavailable
- reject outstanding promises