### PR TITLE
IDv3 support for generating and parsing tokens and UID string

### DIFF
--- a/conf/local-config.json
+++ b/conf/local-config.json
@@ -8,5 +8,7 @@
   "identity_token_expires_after_seconds": 3600,
   "refresh_token_expires_after_seconds": 86400,
   "refresh_identity_token_after_seconds": 900,
+  "generate_v3_tokens": false,
+  "uid2_email_v3": false,
   "enable_v2_encryption": false
 }

--- a/src/main/java/com/uid2/operator/model/IdentityScope.java
+++ b/src/main/java/com/uid2/operator/model/IdentityScope.java
@@ -29,4 +29,11 @@ public enum IdentityScope {
     public final int value;
 
     IdentityScope(int value) { this.value = value; }
+
+    public static IdentityScope fromValue(int value) {
+        switch (value) {
+            case 0: return UID2;
+            default: throw new IllegalArgumentException();
+        }
+    }
 }

--- a/src/main/java/com/uid2/operator/model/IdentityType.java
+++ b/src/main/java/com/uid2/operator/model/IdentityType.java
@@ -29,4 +29,11 @@ public enum IdentityType {
     public final int value;
 
     IdentityType(int value) { this.value = value; }
+
+    public static IdentityType fromValue(int value) {
+        switch (value) {
+            case 0: return Email;
+            default: throw new IllegalArgumentException();
+        }
+    }
 }

--- a/src/main/java/com/uid2/operator/model/OperatorType.java
+++ b/src/main/java/com/uid2/operator/model/OperatorType.java
@@ -25,9 +25,23 @@ package com.uid2.operator.model;
 
 public enum OperatorType {
     Service(1),
-    Snowflake(17);
+    Snowflake(17),
+    Unknown(-1);
 
     public final int value;
 
-    OperatorType(int value) { this.value = value; }
+    OperatorType(int value) {
+        this.value = value;
+    }
+
+    public static OperatorType fromValue(int value) {
+        switch (value) {
+            case 1:
+                return Service;
+            case 17:
+                return Snowflake;
+            default:
+                return Unknown;
+        }
+    }
 }

--- a/src/main/java/com/uid2/operator/model/RefreshResponse.java
+++ b/src/main/java/com/uid2/operator/model/RefreshResponse.java
@@ -25,22 +25,20 @@ package com.uid2.operator.model;
 
 public class RefreshResponse {
 
-    public static RefreshResponse Invalid = new RefreshResponse(Status.Invalid, IdentityTokens.LogoutToken, null);
-    public static RefreshResponse Optout = new RefreshResponse(Status.Optout, IdentityTokens.LogoutToken, null);
-    public static RefreshResponse Expired = new RefreshResponse(Status.Expired, IdentityTokens.LogoutToken, null);
-    public static RefreshResponse Deprecated = new RefreshResponse(Status.Deprecated, IdentityTokens.LogoutToken, null);
+    public static RefreshResponse Invalid = new RefreshResponse(Status.Invalid, IdentityTokens.LogoutToken);
+    public static RefreshResponse Optout = new RefreshResponse(Status.Optout, IdentityTokens.LogoutToken);
+    public static RefreshResponse Expired = new RefreshResponse(Status.Expired, IdentityTokens.LogoutToken);
+    public static RefreshResponse Deprecated = new RefreshResponse(Status.Deprecated, IdentityTokens.LogoutToken);
     private final Status status;
     private final IdentityTokens tokens;
-    private final byte[] responseEncryptionKey;
 
-    private RefreshResponse(Status status, IdentityTokens tokens, byte[] responseEncryptionKey) {
+    private RefreshResponse(Status status, IdentityTokens tokens) {
         this.status = status;
         this.tokens = tokens;
-        this.responseEncryptionKey = responseEncryptionKey;
     }
 
-    public static RefreshResponse Refreshed(IdentityTokens tokens, byte[] responseEncryptionKey) {
-        return new RefreshResponse(Status.Refreshed, tokens, responseEncryptionKey);
+    public static RefreshResponse Refreshed(IdentityTokens tokens) {
+        return new RefreshResponse(Status.Refreshed, tokens);
     }
 
     public Status getStatus() {
@@ -50,8 +48,6 @@ public class RefreshResponse {
     public IdentityTokens getTokens() {
         return tokens;
     }
-
-    public byte[] getResponseEncryptionKey() { return responseEncryptionKey; }
 
     public boolean isRefreshed() {
         return Status.Refreshed.equals(this.status);

--- a/src/main/java/com/uid2/operator/model/RefreshToken.java
+++ b/src/main/java/com/uid2/operator/model/RefreshToken.java
@@ -29,14 +29,12 @@ public class RefreshToken extends VersionedToken {
     public final OperatorIdentity operatorIdentity;
     public final PublisherIdentity publisherIdentity;
     public final UserIdentity userIdentity;
-    public final byte[] responseEncryptionKey;
 
     public RefreshToken(TokenVersion version, Instant createdAt, Instant expiresAt, OperatorIdentity operatorIdentity,
-                        PublisherIdentity publisherIdentity, UserIdentity userIdentity, byte[] responseEncryptionKey) {
+                        PublisherIdentity publisherIdentity, UserIdentity userIdentity) {
         super(version, createdAt, expiresAt);
         this.operatorIdentity = operatorIdentity;
         this.publisherIdentity = publisherIdentity;
         this.userIdentity = userIdentity;
-        this.responseEncryptionKey = responseEncryptionKey;
     }
 }

--- a/src/main/java/com/uid2/operator/service/EncryptionHelper.java
+++ b/src/main/java/com/uid2/operator/service/EncryptionHelper.java
@@ -127,7 +127,7 @@ public class EncryptionHelper {
         try {
             return decryptGCM(encryptedBytes, offset, key.getKeyBytes());
         } catch (Exception e) {
-            throw new RuntimeException("Unable to Encrypt", e);
+            throw new RuntimeException("Unable to Decrypt", e);
         }
     }
 
@@ -139,7 +139,8 @@ public class EncryptionHelper {
             c.init(Cipher.DECRYPT_MODE, key, gcmParameterSpec);
             return c.doFinal(encryptedBytes, offset + GCM_IV_LENGTH, encryptedBytes.length - offset - GCM_IV_LENGTH);
         } catch (Exception e) {
-            throw new RuntimeException("Unable to Encrypt", e);
+            System.err.println(e);
+            throw new RuntimeException("Unable to Decrypt", e);
         }
     }
 

--- a/src/main/java/com/uid2/operator/service/TokenUtils.java
+++ b/src/main/java/com/uid2/operator/service/TokenUtils.java
@@ -23,6 +23,9 @@
 
 package com.uid2.operator.service;
 
+import com.uid2.operator.model.IdentityScope;
+import com.uid2.operator.model.IdentityType;
+
 public class TokenUtils {
     public static byte[] getIdentityHash(String identityString) {
         return EncodingUtils.getSha256Bytes(identityString);
@@ -54,5 +57,13 @@ public class TokenUtils {
 
     public static byte[] getAdvertisingIdV2FromIdentityHash(String identityString, String firstLevelSalt, String rotatingSalt) {
         return getAdvertisingIdV2(getFirstLevelHashFromIdentityHash(identityString, firstLevelSalt), rotatingSalt);
+    }
+
+    public static byte[] getAdvertisingIdV3(IdentityScope scope, IdentityType type, byte[] firstLevelHash, String rotatingSalt) {
+        final byte[] sha = EncodingUtils.getSha256Bytes(EncodingUtils.toBase64String(firstLevelHash), rotatingSalt);
+        final byte[] id = new byte[33];
+        id[0] = (byte)((scope.value << 4) | (type.value << 2));
+        System.arraycopy(sha, 0, id, 1, 32);
+        return id;
     }
 }

--- a/src/main/resources/com.uid2.core/test/keys/keys.json
+++ b/src/main/resources/com.uid2.core/test/keys/keys.json
@@ -22,5 +22,13 @@
     "created": 1609459200,
     "activates": 1609469200,
     "expires": 1893456000
+  },
+  {
+    "id": 5,
+    "site_id": 3,
+    "secret": "bVZZOwCuO0fUf2P6CrwaY23erMErVQiMkGgpy2OMSxc=",
+    "created": 1609459200,
+    "activates": 1609469200,
+    "expires": 1893456000
   }
 ]

--- a/src/test/java/com/uid2/operator/TokenEncodingTest.java
+++ b/src/test/java/com/uid2/operator/TokenEncodingTest.java
@@ -62,8 +62,7 @@ public class TokenEncodingTest {
             now.plusSeconds(360),
             new OperatorIdentity(101, OperatorType.Service, 102, 103),
             new PublisherIdentity(111, 112, 113),
-            new UserIdentity(IdentityScope.UID2, IdentityType.Email, "some-id".getBytes(StandardCharsets.UTF_8), 121, now, now.minusSeconds(122)),
-            null
+            new UserIdentity(IdentityScope.UID2, IdentityType.Email, "some-id".getBytes(StandardCharsets.UTF_8), 121, now, now.minusSeconds(122))
         );
 
         final byte[] encodedBytes = encoder.encode(token, now);


### PR DESCRIPTION
- config controls whether ID v2 or v3 is to be generated for UID2 emails
- config controls whether v2 or v3 advertising/refresh tokens are to be generated
- enable parsing both v2 and v3 tokens