### PR TITLE
Allow setupGoogleTag in JS SDK to be called prior to googleTag loading

### DIFF
--- a/js/uid2-sdk-1.0.0/basic.test.js
+++ b/js/uid2-sdk-1.0.0/basic.test.js
@@ -46,19 +46,34 @@ const getUid2Cookie = mocks.getUid2Cookie;
 const makeIdentity = mocks.makeIdentity;
 
 describe('When google tag setup is called', () => {
-  it('should not fail when there is no googletag', () => {
-    sdk.window.googletag = null;
-    expect(() => sdk.UID2.setupGoogleTag()).not.toThrow(TypeError);
-  });
-  it('should not fail when there is no googletag encryptedSignalProviders', () => {
-    sdk.window.googletag = {encryptedSignalProviders: null};
-    expect(() => sdk.UID2.setupGoogleTag()).not.toThrow(TypeError);
-  });
-  it('should push if googletag has encryptedSignalProviders', () => {
-    const mockPush = jest.fn();
-    sdk.window.googletag = {encryptedSignalProviders: {push: mockPush}};
+  it('should define googletag and encryptedSignalProviders and push the uidapi.com signal provider if googletag is not yet defined', () => {
+    sdk.window.googletag = undefined;
     sdk.UID2.setupGoogleTag();
-    expect(mockPush.mock.calls.length).toBe(1);
+    const providers = sdk.window.googletag.encryptedSignalProviders;
+    expect(providers.length).toBe(1);
+    expect(providers[0].id).toBe('uidapi.com')
+  });
+  it('should define encryptedSignalProviders and push the uidapi.com signal provider if encryptedSignalProviders is not defined', () => {
+    sdk.window.googletag = {};
+    sdk.UID2.setupGoogleTag();
+    const providers = sdk.window.googletag.encryptedSignalProviders;
+    expect(providers.length).toBe(1);
+    expect(providers[0].id).toBe('uidapi.com')
+  });
+  it('should push uidapi.com signal provider if googletag has encryptedSignalProviders defined already', () => {
+    sdk.window.googletag = {
+      encryptedSignalProviders: [
+        {
+          id: 'another-provider',
+          collectorFunction: () => {}
+        }
+      ]
+    };
+    sdk.UID2.setupGoogleTag();
+    const providers = sdk.window.googletag.encryptedSignalProviders;
+    expect(providers.length).toBe(2);
+    expect(providers[0].id).toBe('another-provider');
+    expect(providers[1].id).toBe('uidapi.com')
   });
 });
 

--- a/js/uid2-sdk-1.0.0/package-lock.json
+++ b/js/uid2-sdk-1.0.0/package-lock.json
@@ -3208,7 +3208,7 @@
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.6"
+        "minimist": "^1.2.5"
       }
     },
     "kleur": {
@@ -4037,7 +4037,7 @@
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
       },
       "dependencies": {
@@ -4047,7 +4047,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.6"
+            "minimist": "^1.2.0"
           }
         },
         "strip-bom": {

--- a/static/js/uid2-sdk-1.0.0.js
+++ b/static/js/uid2-sdk-1.0.0.js
@@ -34,18 +34,22 @@ class UID2 {
     }
 
     static setupGoogleTag() {
-      if (window.googletag && window.googletag.encryptedSignalProviders) {
-          googletag.encryptedSignalProviders.push({
-              id: 'uidapi.com',
-              collectorFunction: () => {
-                  if (window.__uid2 && window.__uid2.getAdvertisingToken) {
-                      return __uid2.getAdvertisingTokenAsync();
-                  } else {
-                      return Promise.reject(new Error("UID2 SDK not present"));
-                  }
-              }
-          });
-      }
+        if (!window.googletag) {
+            window.googletag = {};
+        }
+        if (!googletag.encryptedSignalProviders) {
+            googletag.encryptedSignalProviders = [];
+        }
+        googletag.encryptedSignalProviders.push({
+            id: "uidapi.com",
+            collectorFunction: () => {
+                if (window.__uid2 && window.__uid2.getAdvertisingTokenAsync) {
+                    return __uid2.getAdvertisingTokenAsync();
+                } else {
+                    return Promise.reject(new Error("UID2 SDK not present"));
+                }
+            },
+        });
     }
 
     constructor() {


### PR DESCRIPTION
Presently, if `googletag` is not defined on the window when the uid2 js script is loaded, the `encryptedSignalProviders.push` call is not made and therefore the `collectorFunction` is never called.

In this situation where `googletag` is not defined, you can define`window.googletag.encryptedSignalProviders` with the desired object and googletag will pick it up when its js loads. This PR implements that change.

