### PR TITLE
Update SDK callback parameter naming

### DIFF
--- a/js/euid-sdk-1.0.0/basic.test.js
+++ b/js/euid-sdk-1.0.0/basic.test.js
@@ -85,6 +85,7 @@ describe('when called with incomplete identity', () => {
     delete identity["advertising_token"];
     euid.init({ callback: callback, identity: identity });
     expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: -2,
         statusText: "advertising_token is not available or is not valid"
@@ -95,6 +96,7 @@ describe('when called with incomplete identity', () => {
     delete identity["refresh_token"];
     euid.init({ callback: callback, identity: identity });
     expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      advertisingToken: undefined,
       advertising_token: undefined,
       status: -2,
       statusText: "refresh_token is not available or is not valid"
@@ -105,6 +107,7 @@ describe('when called with incomplete identity', () => {
     delete identity["refresh_from"];
     euid.init({ callback: callback, identity: identity });
     expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      advertisingToken: undefined,
       advertising_token: undefined,
       status: -2,
       statusText: "refresh_from is not available or is not valid"
@@ -115,6 +118,7 @@ describe('when called with incomplete identity', () => {
     delete identity["identity_expires"];
     euid.init({ callback: callback, identity: identity });
     expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      advertisingToken: undefined,
       advertising_token: undefined,
       status: -2,
       statusText: "identity_expires is not available or is not valid"
@@ -125,6 +129,7 @@ describe('when called with incomplete identity', () => {
     delete identity["refresh_expires"];
     euid.init({ callback: callback, identity: identity });
     expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      advertisingToken: undefined,
       advertising_token: undefined,
       status: -2,
       statusText: "refresh_expires is not available or is not valid"
@@ -145,6 +150,7 @@ describe('when initialised without identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.EUID.IdentityStatus.NO_IDENTITY,
       }));
@@ -169,6 +175,7 @@ describe('when initialised without identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.EUID.IdentityStatus.INVALID,
       }));
@@ -195,6 +202,7 @@ describe('when initialised without identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: identity.advertising_token,
         advertising_token: identity.advertising_token,
         status: sdk.EUID.IdentityStatus.ESTABLISHED,
       }));
@@ -223,6 +231,7 @@ describe('when initialised without identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.EUID.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -299,6 +308,7 @@ describe('when initialised with specific identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.EUID.IdentityStatus.INVALID,
       }));
@@ -324,6 +334,7 @@ describe('when initialised with specific identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: identity.advertising_token,
         advertising_token: identity.advertising_token,
         status: sdk.EUID.IdentityStatus.ESTABLISHED,
       }));
@@ -355,6 +366,7 @@ describe('when initialised with specific identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: initIdentity.advertising_token,
         advertising_token: initIdentity.advertising_token,
         status: sdk.EUID.IdentityStatus.ESTABLISHED,
       }));
@@ -393,6 +405,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
         advertising_token: updatedIdentity.advertising_token,
         status: sdk.EUID.IdentityStatus.REFRESHED,
       }));
@@ -417,6 +430,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.EUID.IdentityStatus.ESTABLISHED,
       }));
@@ -441,6 +455,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.EUID.IdentityStatus.OPTOUT,
       }));
@@ -466,6 +481,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.EUID.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -490,6 +506,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.EUID.IdentityStatus.ESTABLISHED,
       }));
@@ -514,6 +531,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.EUID.IdentityStatus.ESTABLISHED,
       }));
@@ -538,6 +556,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.EUID.IdentityStatus.ESTABLISHED,
       }));
@@ -562,6 +581,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.EUID.IdentityStatus.ESTABLISHED,
       }));
@@ -587,6 +607,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.EUID.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -626,6 +647,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
         advertising_token: updatedIdentity.advertising_token,
         status: sdk.EUID.IdentityStatus.REFRESHED,
       }));
@@ -650,6 +672,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.EUID.IdentityStatus.OPTOUT,
       }));
@@ -675,6 +698,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.EUID.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -699,6 +723,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.EUID.IdentityStatus.EXPIRED,
       }));
@@ -724,6 +749,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.EUID.IdentityStatus.REFRESH_EXPIRED,
       }));

--- a/js/euid-sdk-1.0.0/compatibility.test.js
+++ b/js/euid-sdk-1.0.0/compatibility.test.js
@@ -78,6 +78,7 @@ describe('when a v0 cookie is available', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
         advertising_token: updatedIdentity.advertising_token,
         status: sdk.EUID.IdentityStatus.REFRESHED,
       }));
@@ -102,6 +103,7 @@ describe('when a v0 cookie is available', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.EUID.IdentityStatus.ESTABLISHED,
       }));

--- a/js/uid2-sdk-1.0.0/autoRefresh.test.js
+++ b/js/uid2-sdk-1.0.0/autoRefresh.test.js
@@ -105,6 +105,7 @@ describe('when auto refreshing a non-expired identity which requires a refresh',
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
         advertising_token: updatedIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.REFRESHED,
       }));
@@ -129,6 +130,7 @@ describe('when auto refreshing a non-expired identity which requires a refresh',
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.OPTOUT,
       }));
@@ -153,6 +155,7 @@ describe('when auto refreshing a non-expired identity which requires a refresh',
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -199,6 +202,7 @@ describe('when auto refreshing a non-expired identity which requires a refresh',
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -256,6 +260,7 @@ describe('when auto refreshing an expired identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
         advertising_token: updatedIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.REFRESHED,
       }));
@@ -280,6 +285,7 @@ describe('when auto refreshing an expired identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.OPTOUT,
       }));
@@ -304,6 +310,7 @@ describe('when auto refreshing an expired identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -328,6 +335,7 @@ describe('when auto refreshing an expired identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.EXPIRED,
       }));
@@ -353,6 +361,7 @@ describe('when auto refreshing an expired identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));

--- a/js/uid2-sdk-1.0.0/basic.test.js
+++ b/js/uid2-sdk-1.0.0/basic.test.js
@@ -121,6 +121,7 @@ describe('when initialised without identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.NO_IDENTITY,
       }));
@@ -145,6 +146,7 @@ describe('when initialised without identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.INVALID,
       }));
@@ -171,6 +173,7 @@ describe('when initialised without identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: identity.advertising_token,
         advertising_token: identity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -199,6 +202,7 @@ describe('when initialised without identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -291,6 +295,7 @@ describe('when initialised with specific identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.INVALID,
       }));
@@ -316,6 +321,7 @@ describe('when initialised with specific identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: identity.advertising_token,
         advertising_token: identity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -341,6 +347,7 @@ describe('when initialised with specific identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: identity.advertising_token,
         advertising_token: identity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -372,6 +379,7 @@ describe('when initialised with specific identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: initIdentity.advertising_token,
         advertising_token: initIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -410,6 +418,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
         advertising_token: updatedIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.REFRESHED,
       }));
@@ -434,6 +443,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -458,6 +468,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.OPTOUT,
       }));
@@ -482,6 +493,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -506,6 +518,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -530,6 +543,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -554,6 +568,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -578,6 +593,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -603,6 +619,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -642,6 +659,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
         advertising_token: updatedIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.REFRESHED,
       }));
@@ -666,6 +684,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.OPTOUT,
       }));
@@ -690,6 +709,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -714,6 +734,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.EXPIRED,
       }));
@@ -739,6 +760,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));

--- a/js/uid2-sdk-1.0.0/compatibility.test.js
+++ b/js/uid2-sdk-1.0.0/compatibility.test.js
@@ -78,6 +78,7 @@ describe('when a v0 cookie is available', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
         advertising_token: updatedIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.REFRESHED,
       }));
@@ -102,6 +103,7 @@ describe('when a v0 cookie is available', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));

--- a/js/uid2-sdk-2.0.0/autoRefresh.test.js
+++ b/js/uid2-sdk-2.0.0/autoRefresh.test.js
@@ -107,6 +107,7 @@ describe('when auto refreshing a non-expired identity which requires a refresh',
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
         advertising_token: updatedIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.REFRESHED,
       }));
@@ -131,6 +132,7 @@ describe('when auto refreshing a non-expired identity which requires a refresh',
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.OPTOUT,
       }));
@@ -155,6 +157,7 @@ describe('when auto refreshing a non-expired identity which requires a refresh',
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -201,6 +204,7 @@ describe('when auto refreshing a non-expired identity which requires a refresh',
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -258,6 +262,7 @@ describe('when auto refreshing an expired identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
         advertising_token: updatedIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.REFRESHED,
       }));
@@ -282,6 +287,7 @@ describe('when auto refreshing an expired identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.OPTOUT,
       }));
@@ -306,6 +312,7 @@ describe('when auto refreshing an expired identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -330,6 +337,7 @@ describe('when auto refreshing an expired identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.EXPIRED,
       }));
@@ -355,6 +363,7 @@ describe('when auto refreshing an expired identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));

--- a/js/uid2-sdk-2.0.0/basic.test.js
+++ b/js/uid2-sdk-2.0.0/basic.test.js
@@ -109,6 +109,7 @@ describe('when initialised without identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.NO_IDENTITY,
       }));
@@ -133,6 +134,7 @@ describe('when initialised without identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.INVALID,
       }));
@@ -159,6 +161,7 @@ describe('when initialised without identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: identity.advertising_token,
         advertising_token: identity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -187,6 +190,7 @@ describe('when initialised without identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -283,6 +287,7 @@ describe('when initialised with specific identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.INVALID,
       }));
@@ -308,6 +313,7 @@ describe('when initialised with specific identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: identity.advertising_token,
         advertising_token: identity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -339,6 +345,7 @@ describe('when initialised with specific identity', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: initIdentity.advertising_token,
         advertising_token: initIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -377,6 +384,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
         advertising_token: updatedIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.REFRESHED,
       }));
@@ -401,6 +409,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -425,6 +434,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.OPTOUT,
       }));
@@ -450,6 +460,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -474,6 +485,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -498,6 +510,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -522,6 +535,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -546,6 +560,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));
@@ -571,6 +586,7 @@ describe('when still valid identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -610,6 +626,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: updatedIdentity.advertising_token,
         advertising_token: updatedIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.REFRESHED,
       }));
@@ -634,6 +651,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.OPTOUT,
       }));
@@ -659,6 +677,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));
@@ -683,6 +702,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.EXPIRED,
       }));
@@ -708,6 +728,7 @@ describe('when expired identity is refreshed on init', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: undefined,
         advertising_token: undefined,
         status: sdk.UID2.IdentityStatus.REFRESH_EXPIRED,
       }));

--- a/js/uid2-sdk-2.0.0/compatibility.test.js
+++ b/js/uid2-sdk-2.0.0/compatibility.test.js
@@ -102,6 +102,7 @@ describe('when a v0 cookie is available', () => {
 
     it('should invoke the callback', () => {
       expect(callback).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        advertisingToken: originalIdentity.advertising_token,
         advertising_token: originalIdentity.advertising_token,
         status: sdk.UID2.IdentityStatus.ESTABLISHED,
       }));

--- a/static/js/euid-sdk-1.0.0.js
+++ b/static/js/euid-sdk-1.0.0.js
@@ -148,6 +148,7 @@ class EUID {
             const advertisingToken = this.getAdvertisingToken();
 
             const result = {
+                advertisingToken: advertisingToken,
                 advertising_token: advertisingToken,
                 status: status,
                 statusText: statusText

--- a/static/js/uid2-sdk-1.0.0.js
+++ b/static/js/uid2-sdk-1.0.0.js
@@ -167,6 +167,7 @@ class UID2 {
             const advertisingToken = this.getAdvertisingToken();
 
             const result = {
+                advertisingToken: advertisingToken,
                 advertising_token: advertisingToken,
                 status: status,
                 statusText: statusText

--- a/static/js/uid2-sdk-2.0.0.js
+++ b/static/js/uid2-sdk-2.0.0.js
@@ -168,6 +168,7 @@ class UID2 {
             const advertisingToken = this.getAdvertisingToken();
 
             const result = {
+                advertisingToken: advertisingToken,
                 advertising_token: advertisingToken,
                 status: status,
                 statusText: statusText


### PR DESCRIPTION
According to UnifiedID2/uid2docs#42's feedback from @elenaTTD, I updated the callback naming to make it consistent between doc and real code behavior.

SDK v1 actually has same inconsistency between doc and codes. Should v1's SDK code be renamed too? 

Thank you.