### PR TITLE
New token-generate parameter to respect earlier optout records

### DIFF
--- a/src/main/java/com/uid2/operator/model/IdentityRequest.java
+++ b/src/main/java/com/uid2/operator/model/IdentityRequest.java
@@ -3,9 +3,15 @@ package com.uid2.operator.model;
 public final class IdentityRequest {
     public final PublisherIdentity publisherIdentity;
     public final UserIdentity userIdentity;
+    public final TokenGeneratePolicy tokenGeneratePolicy;
 
-    public IdentityRequest(PublisherIdentity publisherIdentity, UserIdentity userIdentity) {
+    public IdentityRequest(
+            PublisherIdentity publisherIdentity,
+            UserIdentity userIdentity,
+            TokenGeneratePolicy tokenGeneratePolicy)
+    {
         this.publisherIdentity = publisherIdentity;
         this.userIdentity = userIdentity;
+        this.tokenGeneratePolicy = tokenGeneratePolicy;
     }
 }

--- a/src/main/java/com/uid2/operator/model/IdentityRequest.java
+++ b/src/main/java/com/uid2/operator/model/IdentityRequest.java
@@ -14,4 +14,8 @@ public final class IdentityRequest {
         this.userIdentity = userIdentity;
         this.tokenGeneratePolicy = tokenGeneratePolicy;
     }
+
+    public boolean shouldCheckOptOut() {
+        return tokenGeneratePolicy.equals(TokenGeneratePolicy.RespectOptOut);
+    }
 }

--- a/src/main/java/com/uid2/operator/model/IdentityTokens.java
+++ b/src/main/java/com/uid2/operator/model/IdentityTokens.java
@@ -44,4 +44,8 @@ public class IdentityTokens {
     public Instant getRefreshFrom() {
         return refreshFrom;
     }
+
+    public boolean isEmptyToken() {
+        return advertisingToken == null || advertisingToken.isEmpty();
+    }
 }

--- a/src/main/java/com/uid2/operator/model/TokenGeneratePolicy.java
+++ b/src/main/java/com/uid2/operator/model/TokenGeneratePolicy.java
@@ -1,0 +1,22 @@
+package com.uid2.operator.model;
+
+public enum TokenGeneratePolicy {
+    JustGenerate(0),
+    RespectOptOut(1);
+
+    public final int policy;
+
+    TokenGeneratePolicy(int policy) { this.policy = policy; }
+
+    public static TokenGeneratePolicy fromValue(int value) {
+        switch (value) {
+            case 0: return JustGenerate;
+            case 1: return RespectOptOut;
+            default: throw new IllegalArgumentException();
+        }
+    }
+
+    public static TokenGeneratePolicy defaultPolicy() {
+        return JustGenerate;
+    }
+}

--- a/src/main/java/com/uid2/operator/service/EncryptionKeyUtil.java
+++ b/src/main/java/com/uid2/operator/service/EncryptionKeyUtil.java
@@ -9,6 +9,9 @@ public class EncryptionKeyUtil {
     public static EncryptionKey getActiveSiteKey(IKeyStore.IKeyStoreSnapshot keyStoreSnapshot, int siteId, int fallbackSiteId, Instant now) {
         EncryptionKey key = keyStoreSnapshot.getActiveSiteKey(siteId, now);
         if (key == null) key = keyStoreSnapshot.getActiveSiteKey(fallbackSiteId, now);
+        if (key == null) {
+            throw new RuntimeException(String.format("cannot get active site key with ID %d or %d", siteId, fallbackSiteId));
+        }
         return key;
     }
 }

--- a/src/main/java/com/uid2/operator/service/ResponseUtil.java
+++ b/src/main/java/com/uid2/operator/service/ResponseUtil.java
@@ -49,6 +49,16 @@ public class ResponseUtil {
         rc.data().put("response", json);
     }
 
+    public static void OptOutV2(RoutingContext rc, Object body) {
+        final JsonObject json = new JsonObject(new HashMap<String, Object>() {
+            {
+                put("status", UIDOperatorVerticle.ResponseStatus.OptOut);
+                put("body", body);
+            }
+        });
+        rc.data().put("response", json);
+    }
+
     public static void ClientError(RoutingContext rc, String message) {
         Error(UIDOperatorVerticle.ResponseStatus.ClientError, 400, rc, message);
     }

--- a/src/main/java/com/uid2/operator/service/UIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/UIDOperatorService.java
@@ -81,7 +81,7 @@ public class UIDOperatorService implements IUIDOperatorService {
                 request.userIdentity.identityScope, request.userIdentity.identityType, firstLevelHash, request.userIdentity.privacyBits,
                 request.userIdentity.establishedAt, request.userIdentity.refreshedAt);
 
-        if (request.tokenGeneratePolicy.equals(TokenGeneratePolicy.RespectOptOut) && hasGlobalOptOut(firstLevelHashIdentity)) {
+        if (request.shouldCheckOptOut() && hasGlobalOptOut(firstLevelHashIdentity)) {
             return IdentityTokens.LogoutToken;
         } else {
             return generateIdentity(request.publisherIdentity, firstLevelHashIdentity);

--- a/src/main/java/com/uid2/operator/service/UIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/UIDOperatorService.java
@@ -80,7 +80,12 @@ public class UIDOperatorService implements IUIDOperatorService {
         final UserIdentity firstLevelHashIdentity = new UserIdentity(
                 request.userIdentity.identityScope, request.userIdentity.identityType, firstLevelHash, request.userIdentity.privacyBits,
                 request.userIdentity.establishedAt, request.userIdentity.refreshedAt);
-        return generateIdentity(request.publisherIdentity, firstLevelHashIdentity);
+
+        if (request.tokenGeneratePolicy.equals(TokenGeneratePolicy.RespectOptOut) && hasGlobalOptOut(firstLevelHashIdentity)) {
+            return IdentityTokens.LogoutToken;
+        } else {
+            return generateIdentity(request.publisherIdentity, firstLevelHashIdentity);
+        }
     }
 
     @Override
@@ -233,6 +238,10 @@ public class UIDOperatorService implements IUIDOperatorService {
                 this.operatorIdentity,
                 publisherIdentity,
                 userIdentity);
+    }
+
+    private boolean hasGlobalOptOut(UserIdentity userIdentity) {
+        return this.optOutStore.getLatestEntry(userIdentity) != null;
     }
 
 }

--- a/src/main/java/com/uid2/operator/service/V2RequestUtil.java
+++ b/src/main/java/com/uid2/operator/service/V2RequestUtil.java
@@ -99,7 +99,7 @@ public class V2RequestUtil {
                 String bodyStr = new String(decryptedBody, 16, decryptedBody.length - 16, StandardCharsets.UTF_8);
                 payload = new JsonObject(bodyStr);
             } catch (Exception ex) {
-                LOGGER.error(ex);
+                LOGGER.error("Invalid payload in body: Data is not valid json string.", ex);
                 return new V2Request("Invalid payload in body: Data is not valid json string.");
             }
         }
@@ -132,7 +132,7 @@ public class V2RequestUtil {
         try {
             decrypted = AesGcm.decrypt(bytes, 5, key);
         } catch (Exception ex) {
-            LOGGER.error(ex);
+            LOGGER.error("Invalid data: Check encryption method and encryption key", ex);
             return new V2Request("Invalid data: Check encryption method and encryption key");
         }
 
@@ -143,7 +143,7 @@ public class V2RequestUtil {
 
             return new V2Request(null, refreshToken, responseKey);
         } catch (Exception ex) {
-            LOGGER.error(ex);
+            LOGGER.error("Invalid format: Payload is not valid json or missing required data", ex);
             return new V2Request("Invalid format: Payload is not valid json or missing required data");
         }
     }

--- a/src/main/java/com/uid2/operator/store/IOptOutStore.java
+++ b/src/main/java/com/uid2/operator/store/IOptOutStore.java
@@ -8,6 +8,11 @@ import java.time.Instant;
 
 public interface IOptOutStore {
 
+    /**
+     * Get latest Opt-out record with respect to the UID (hashed identity)
+     * @param firstLevelHashIdentity UID
+     * @return The timestamp of latest opt-out record. <b>NULL</b> if no record.
+     */
     Instant getLatestEntry(UserIdentity firstLevelHashIdentity);
 
     void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, Handler<AsyncResult<Instant>> handler);

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -464,7 +464,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
                 }
             }
         } catch (IllegalArgumentException iae) {
-            LOGGER.warn(iae);
+            LOGGER.warn("request body contains invalid argument(s)", iae);
             ResponseUtil.ClientError(rc, "request body contains invalid argument(s)");
         } catch (Exception e) {
             LOGGER.error("Unknown error while generating token v2", e);

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -456,7 +456,12 @@ public class UIDOperatorVerticle extends AbstractVerticle{
                         new PublisherIdentity(clientKey.getSiteId(), 0, 0),
                         input.toUserIdentity(this.identityScope, 1, Instant.now()),
                         readTokenGeneratePolicy(req)));
-                ResponseUtil.SuccessV2(rc, toJsonV1(t));
+
+                if (t.isEmptyToken()) {
+                    ResponseUtil.OptOutV2(rc, toJsonV1(t));
+                } else {
+                    ResponseUtil.SuccessV2(rc, toJsonV1(t));
+                }
             }
         } catch (IllegalArgumentException iae) {
             LOGGER.warn(iae);

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -589,7 +589,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
                     .write(String.valueOf(timestamp))
                     .end();
             } catch (Exception ex) {
-                LOGGER.error(ex);
+                LOGGER.error("Unexpected error while handling optout get", ex);
                 rc.fail(500);
             }
         } else {
@@ -689,7 +689,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
             }
         }
         catch (Exception ex) {
-            LOGGER.error(ex);
+            LOGGER.error("Unexpected error while mapping identity", ex);
             rc.fail(500);
         }
     }

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -234,7 +234,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
         try {
             handleKeysRequestCommon(rc, keys -> ResponseUtil.Success(rc, keys));
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while handling keys request v1", e);
             rc.fail(500);
         }
     }
@@ -243,7 +243,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
         try {
             handleKeysRequestCommon(rc, keys -> ResponseUtil.SuccessV2(rc, keys));
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while handling keys request v2", e);
             rc.fail(500);
         }
     }
@@ -252,7 +252,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
         try {
             handleKeysRequestCommon(rc, keys -> sendJsonResponse(rc, keys));
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while handling keys request", e);
             rc.fail(500);
         }
     }
@@ -310,7 +310,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
                 ResponseUtil.Success(rc, toJsonV1(r.getTokens()));
             }
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("unknown error while refreshing token", e);
             ResponseUtil.Error(ResponseStatus.UnknownError, 500, rc, "Service Error");
         }
     }
@@ -337,7 +337,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
                 ResponseUtil.SuccessV2(rc, toJsonV1(r.getTokens()));
             }
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while refreshing token v2", e);
             ResponseUtil.Error(ResponseStatus.UnknownError, 500, rc, "Service Error");
         }
     }
@@ -364,7 +364,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
                 ResponseUtil.Success(rc, Boolean.FALSE);
             }
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while validating token", e);
             rc.fail(500);
         }
     }
@@ -395,7 +395,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
                 ResponseUtil.SuccessV2(rc, Boolean.FALSE);
             }
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while validating token v2", e);
             rc.fail(500);
         }
     }
@@ -418,7 +418,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
                 ResponseUtil.Success(rc, toJsonV1(t));
             }
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while generating token v1", e);
             rc.fail(500);
         }
     }
@@ -467,7 +467,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
             LOGGER.warn(iae);
             ResponseUtil.ClientError(rc, "request body contains invalid argument(s)");
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while generating token v2", e);
             rc.fail(500);
         }
     }
@@ -492,7 +492,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
             sendJsonResponse(rc, toJson(t));
 
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while generating token", e);
             rc.fail(500);
         }
     }
@@ -508,7 +508,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
             final RefreshResponse r = this.idService.refreshIdentity(tokenList.get(0));
             sendJsonResponse(rc, toJson(r.getTokens()));
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while refreshing token", e);
             rc.fail(500);
         }
     }
@@ -531,7 +531,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
                 rc.response().end("not allowed");
             }
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while validating token", e);
             rc.fail(500);
         }
     }
@@ -671,7 +671,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
             jsonObject.put("bucket_id", mappedIdentity.bucketId);
             ResponseUtil.Success(rc, jsonObject);
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while mapping identity v1", e);
             ResponseUtil.Error(ResponseStatus.UnknownError, 500, rc, "Unknown State");
         }
     }
@@ -899,7 +899,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
             resp.put("mapped", mapped);
             ResponseUtil.Success(rc, resp);
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while mapping batched identity", e);
             ResponseUtil.Error(ResponseStatus.UnknownError, 500, rc, "Unknown State");
         }
     }
@@ -936,7 +936,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
             resp.put("mapped", mapped);
             ResponseUtil.SuccessV2(rc, resp);
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while mapping identity v2", e);
             ResponseUtil.Error(ResponseStatus.UnknownError, 500, rc, "Unknown State");
         }
     }
@@ -1023,7 +1023,7 @@ public class UIDOperatorVerticle extends AbstractVerticle{
             resp.put("mapped", mapped);
             sendJsonResponse(rc, resp);
         } catch (Exception e) {
-            LOGGER.error(e);
+            LOGGER.error("Unknown error while mapping batched identity", e);
             rc.fail(500);
         }
     }

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -410,7 +410,8 @@ public class UIDOperatorVerticle extends AbstractVerticle{
                 final IdentityTokens t = this.idService.generateIdentity(
                     new IdentityRequest(
                         new PublisherIdentity(clientKey.getSiteId(), 0, 0),
-                        input.toUserIdentity(this.identityScope, 1, Instant.now())));
+                        input.toUserIdentity(this.identityScope, 1, Instant.now()),
+                        TokenGeneratePolicy.defaultPolicy()));
 
                 //Integer.parseInt(rc.queryParam("privacy_bits").get(0))));
 
@@ -453,9 +454,13 @@ public class UIDOperatorVerticle extends AbstractVerticle{
                 final IdentityTokens t = this.idService.generateIdentity(
                     new IdentityRequest(
                         new PublisherIdentity(clientKey.getSiteId(), 0, 0),
-                        input.toUserIdentity(this.identityScope, 1, Instant.now())));
+                        input.toUserIdentity(this.identityScope, 1, Instant.now()),
+                        readTokenGeneratePolicy(req)));
                 ResponseUtil.SuccessV2(rc, toJsonV1(t));
             }
+        } catch (IllegalArgumentException iae) {
+            LOGGER.warn(iae);
+            ResponseUtil.ClientError(rc, "request body contains invalid argument(s)");
         } catch (Exception e) {
             LOGGER.error(e);
             rc.fail(500);
@@ -474,7 +479,8 @@ public class UIDOperatorVerticle extends AbstractVerticle{
             final IdentityTokens t = this.idService.generateIdentity(
                     new IdentityRequest(
                             new PublisherIdentity(clientKey.getSiteId(), 0, 0),
-                            input.toUserIdentity(this.identityScope, 1, Instant.now())));
+                            input.toUserIdentity(this.identityScope, 1, Instant.now()),
+                            TokenGeneratePolicy.defaultPolicy()));
 
             //Integer.parseInt(rc.queryParam("privacy_bits").get(0))));
 
@@ -1131,6 +1137,13 @@ public class UIDOperatorVerticle extends AbstractVerticle{
         }
 
         return UserConsentStatus.SUFFICIENT;
+    }
+
+    private static final String TOKEN_GENERATE_POLICY_PARAM = "policy";
+    private TokenGeneratePolicy readTokenGeneratePolicy(JsonObject req) {
+        return req.containsKey(TOKEN_GENERATE_POLICY_PARAM) ?
+            TokenGeneratePolicy.fromValue(req.getInteger(TOKEN_GENERATE_POLICY_PARAM)) :
+                TokenGeneratePolicy.defaultPolicy();
     }
 
     private TransparentConsentParseResult getUserConsentV2(JsonObject req) {

--- a/src/main/java/com/uid2/operator/vertx/V2PayloadHandler.java
+++ b/src/main/java/com/uid2/operator/vertx/V2PayloadHandler.java
@@ -94,7 +94,7 @@ public class V2PayloadHandler {
             JsonObject respJson = (JsonObject) rc.data().get("response");
 
             // DevNote: 200 does not guarantee a token.
-            if (respJson.containsKey("body")) {
+            if (respJson.getString("status").equals(UIDOperatorVerticle.ResponseStatus.Success) && respJson.containsKey("body")) {
                 V2RequestUtil.handleRefreshTokenInResponseBody(respJson.getJsonObject("body"), keyStore, this.identityScope);
             }
 


### PR DESCRIPTION
1. v2/token/generate accepts an optional parameter in body "policy" (integer). 0 = old behavior, 1 = respects opt out record
2. trying to generate a token for a user who opted out will return empty string as advertising token