### PR TITLE
Fix stats collection for unauthenticated non-existing static endpoints.

### DIFF
--- a/src/main/java/com/uid2/operator/monitoring/StatsCollectorHandler.java
+++ b/src/main/java/com/uid2/operator/monitoring/StatsCollectorHandler.java
@@ -29,10 +29,12 @@ public class StatsCollectorHandler implements Handler<RoutingContext> {
         routingContext.next();
         assert routingContext != null;
 
-        String path = routingContext.request().path();
-        String referer = routingContext.request().headers().get("Referer");
-        ClientKey clientKey = (ClientKey) AuthMiddleware.getAuthClient(routingContext);
-        StatsCollectorMessageItem messageItem = new StatsCollectorMessageItem(path, referer, clientKey.getContact(), clientKey.getSiteId());
+        final String path = routingContext.request().path();
+        final String referer = routingContext.request().headers().get("Referer");
+        final ClientKey clientKey = (ClientKey) AuthMiddleware.getAuthClient(routingContext);
+        final String apiContact = clientKey == null ? null : clientKey.getContact();
+        final Integer siteId = clientKey == null ? null : clientKey.getSiteId();
+        final StatsCollectorMessageItem messageItem = new StatsCollectorMessageItem(path, referer, apiContact, siteId);
 
         _statCollectorQueue.enqueue(vertx, messageItem);
     }

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -158,8 +158,8 @@ public class UIDOperatorVerticle extends AbstractVerticle{
             .allowedHeader("Content-Type"));
         router.route().handler(BodyHandler.create().setBodyLimit(MAX_REQUEST_BODY_SIZE));
 
-        router.route("/static/*").handler(StaticHandler.create("static"));
         router.route().handler(new StatsCollectorHandler(_statsCollectorQueue, vertx));
+        router.route("/static/*").handler(StaticHandler.create("static"));
 
         setupV2Routes(router);
 

--- a/src/test/java/com/uid2/operator/StatsCollectorHandlerTest.java
+++ b/src/test/java/com/uid2/operator/StatsCollectorHandlerTest.java
@@ -1,0 +1,89 @@
+package com.uid2.operator;
+
+import com.uid2.operator.model.StatsCollectorMessageItem;
+import com.uid2.operator.monitoring.IStatsCollectorQueue;
+import com.uid2.operator.monitoring.StatsCollectorHandler;
+import com.uid2.shared.auth.ClientKey;
+import com.uid2.shared.middleware.AuthMiddleware;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StatsCollectorHandlerTest {
+    @Mock private RoutingContext routingContext;
+    @Mock private HttpServerRequest request;
+    @Mock private IStatsCollectorQueue statsCollectorQueue;
+    @Mock private Vertx vertx;
+    private final HashMap<String, Object> routingContextData = new HashMap<>();
+    private StatsCollectorHandler handler;
+
+    @Before
+    public void setup() {
+        handler = new StatsCollectorHandler(statsCollectorQueue, vertx);
+        when(routingContext.request()).thenReturn(request);
+        when(routingContext.data()).thenReturn(routingContextData);
+    }
+
+    @Test public void requestWithClientKey() {
+        final ClientKey clientKey = new ClientKey("test-key", "", "test-contact").withSiteId(123);
+        AuthMiddleware.setAuthClient(routingContext, clientKey);
+        when(request.path()).thenReturn("test-path");
+        when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+
+        handler.handle(routingContext);
+
+        final ArgumentCaptor<StatsCollectorMessageItem> messageCaptor = ArgumentCaptor.forClass(StatsCollectorMessageItem.class);
+        verify(statsCollectorQueue).enqueue(any(), messageCaptor.capture());
+
+        final StatsCollectorMessageItem messageItem = messageCaptor.getValue();
+        Assert.assertEquals("test-path", messageItem.getPath());
+        Assert.assertEquals("test-contact", messageItem.getApiContact());
+        Assert.assertEquals(null, messageItem.getReferer());
+        Assert.assertEquals(Integer.valueOf(123), messageItem.getSiteId());
+    }
+
+    @Test public void requestWithoutClientKeyOrReferer() {
+        when(request.path()).thenReturn("test-path");
+        when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+
+        handler.handle(routingContext);
+
+        final ArgumentCaptor<StatsCollectorMessageItem> messageCaptor = ArgumentCaptor.forClass(StatsCollectorMessageItem.class);
+        verify(statsCollectorQueue).enqueue(any(), messageCaptor.capture());
+
+        final StatsCollectorMessageItem messageItem = messageCaptor.getValue();
+        Assert.assertEquals("test-path", messageItem.getPath());
+        Assert.assertEquals(null, messageItem.getApiContact());
+        Assert.assertEquals(null, messageItem.getReferer());
+        Assert.assertEquals(null, messageItem.getSiteId());
+    }
+
+    @Test public void requestWithReferer() {
+        when(request.path()).thenReturn("test-path");
+        when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap().add("Referer", "test-referer"));
+
+        handler.handle(routingContext);
+
+        final ArgumentCaptor<StatsCollectorMessageItem> messageCaptor = ArgumentCaptor.forClass(StatsCollectorMessageItem.class);
+        verify(statsCollectorQueue).enqueue(any(), messageCaptor.capture());
+
+        final StatsCollectorMessageItem messageItem = messageCaptor.getValue();
+        Assert.assertEquals("test-path", messageItem.getPath());
+        Assert.assertEquals(null, messageItem.getApiContact());
+        Assert.assertEquals("test-referer", messageItem.getReferer());
+        Assert.assertEquals(null, messageItem.getSiteId());
+    }
+}


### PR DESCRIPTION
- Avoid null exception if no auth provided and specific (static) path does not exist.
- Collect stats for existing static paths too (previously they were not collected).