### PR TITLE
Added needs statements to require jobs to run serially to stop port contention

### DIFF
--- a/.github/workflows/validate-image.yaml
+++ b/.github/workflows/validate-image.yaml
@@ -22,9 +22,11 @@ jobs:
       failure_severity: ${{ inputs.failure_severity || 'CRITICAL'}}
       cloud_provider: 'aws'
     secrets: inherit
+    needs: [build-publish-docker-default]
   build-publish-docker-gcp:
     uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-validate-image.yaml@main
     with: 
       failure_severity: ${{ inputs.failure_severity || 'CRITICAL'}}
       cloud_provider: 'gcp'
     secrets: inherit
+    needs: [build-publish-docker-aws]


### PR DESCRIPTION
Running the tests in parallel results in contention on the test port.
Relates to UID2-641, not UID2-577