### PR TITLE
Syw UID2-1224 special email opt out handling

### DIFF
--- a/src/main/java/com/uid2/operator/service/UIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/UIDOperatorService.java
@@ -32,10 +32,6 @@ public class UIDOperatorService implements IUIDOperatorService {
     private final IdentityScope identityScope;
     private final UserIdentity testOptOutIdentityForEmail;
     private final UserIdentity testOptOutIdentityForPhone;
-
-    private final UserIdentity testAlwaysOptInIdentityForEmail;
-    private final UserIdentity testAlwaysOptInIdentityForPhone;
-
     private final Duration identityExpiresAfter;
     private final Duration refreshExpiresAfter;
     private final Duration refreshIdentityAfter;
@@ -56,10 +52,6 @@ public class UIDOperatorService implements IUIDOperatorService {
                 InputUtil.normalizeEmail("optout@email.com").getIdentityInput(), Instant.now());
         this.testOptOutIdentityForPhone = getFirstLevelHashIdentity(identityScope, IdentityType.Phone,
                 InputUtil.normalizePhone("+00000000000").getIdentityInput(), Instant.now());
-        this.testAlwaysOptInIdentityForEmail = getFirstLevelHashIdentity(identityScope, IdentityType.Email,
-                InputUtil.normalizeEmail("valid-token@email.com").getIdentityInput(), Instant.now());
-        this.testAlwaysOptInIdentityForPhone = getFirstLevelHashIdentity(identityScope, IdentityType.Phone,
-                InputUtil.normalizePhone("+00000000001").getIdentityInput(), Instant.now());
 
         this.operatorIdentity = new OperatorIdentity(0, OperatorType.Service, 0, 0);
 
@@ -247,9 +239,6 @@ public class UIDOperatorService implements IUIDOperatorService {
     private Tuple.Tuple2<Boolean, Instant> hasGlobalOptOut(UserIdentity userIdentity) {
         if (userIdentity.matches(testOptOutIdentityForEmail) || userIdentity.matches(testOptOutIdentityForPhone)) {
             return new Tuple.Tuple2<>(true, Instant.now());
-        }
-        else if (userIdentity.matches(testAlwaysOptInIdentityForEmail) || userIdentity.matches(testAlwaysOptInIdentityForPhone)) {
-            return new Tuple.Tuple2<>(false, null);
         }
         Instant result = this.optOutStore.getLatestEntry(userIdentity);
         return new Tuple.Tuple2<>(result != null, result);

--- a/src/main/java/com/uid2/operator/service/UIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/UIDOperatorService.java
@@ -85,7 +85,7 @@ public class UIDOperatorService implements IUIDOperatorService {
                 request.userIdentity.identityScope, request.userIdentity.identityType, firstLevelHash, request.userIdentity.privacyBits,
                 request.userIdentity.establishedAt, request.userIdentity.refreshedAt);
 
-        if (request.shouldCheckOptOut() && hasGlobalOptOut(firstLevelHashIdentity).isOptedOut()) {
+        if (request.shouldCheckOptOut() && getGlobalOptOut(firstLevelHashIdentity).isOptedOut()) {
             return IdentityTokens.LogoutToken;
         } else {
             return generateIdentity(request.publisherIdentity, firstLevelHashIdentity);
@@ -108,7 +108,7 @@ public class UIDOperatorService implements IUIDOperatorService {
         }
 
         try {
-            final GlobalOptoutResult logoutEntry = hasGlobalOptOut(token.userIdentity);
+            final GlobalOptoutResult logoutEntry = getGlobalOptOut(token.userIdentity);
             boolean optedOut = logoutEntry.isOptedOut();
 
             if (!optedOut || token.userIdentity.establishedAt.isAfter(logoutEntry.getTime())) {
@@ -125,7 +125,7 @@ public class UIDOperatorService implements IUIDOperatorService {
     @Override
     public MappedIdentity mapIdentity(MapRequest request) {
         final UserIdentity firstLevelHashIdentity = getFirstLevelHashIdentity(request.userIdentity, request.asOf);
-        if (request.shouldCheckOptOut() && hasGlobalOptOut(firstLevelHashIdentity).isOptedOut()) {
+        if (request.shouldCheckOptOut() && getGlobalOptOut(firstLevelHashIdentity).isOptedOut()) {
             return MappedIdentity.LogoutIdentity;
         } else {
             return getAdvertisingId(firstLevelHashIdentity, request.asOf);
@@ -256,7 +256,7 @@ public class UIDOperatorService implements IUIDOperatorService {
         }
     }
 
-    private GlobalOptoutResult hasGlobalOptOut(UserIdentity userIdentity) {
+    private GlobalOptoutResult getGlobalOptOut(UserIdentity userIdentity) {
         if (userIdentity.matches(testOptOutIdentityForEmail) || userIdentity.matches(testOptOutIdentityForPhone)) {
             return new GlobalOptoutResult(Instant.now());
         }

--- a/src/main/java/com/uid2/operator/service/UIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/UIDOperatorService.java
@@ -1,7 +1,6 @@
 package com.uid2.operator.service;
 
 import com.uid2.operator.model.*;
-import com.uid2.operator.util.Tuple;
 import com.uid2.shared.model.SaltEntry;
 import com.uid2.operator.store.IOptOutStore;
 import com.uid2.shared.store.ISaltProvider;
@@ -242,9 +241,9 @@ public class UIDOperatorService implements IUIDOperatorService {
         private final Instant time;
 
         //providedTime can be null if isOptedOut is false!
-        GlobalOptoutResult(boolean providedIsOptedOut, Instant providedTime)
+        GlobalOptoutResult(Instant providedTime)
         {
-            isOptedOut = providedIsOptedOut;
+            isOptedOut = providedTime != null;
             time = providedTime;
         }
 
@@ -259,10 +258,10 @@ public class UIDOperatorService implements IUIDOperatorService {
 
     private GlobalOptoutResult hasGlobalOptOut(UserIdentity userIdentity) {
         if (userIdentity.matches(testOptOutIdentityForEmail) || userIdentity.matches(testOptOutIdentityForPhone)) {
-            return new GlobalOptoutResult(true, Instant.now());
+            return new GlobalOptoutResult(Instant.now());
         }
         Instant result = this.optOutStore.getLatestEntry(userIdentity);
-        return new GlobalOptoutResult(result != null, result);
+        return new GlobalOptoutResult(result);
     }
 
 }

--- a/src/main/java/com/uid2/operator/service/UIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/UIDOperatorService.java
@@ -237,9 +237,9 @@ public class UIDOperatorService implements IUIDOperatorService {
     }
 
     protected class GlobalOptoutResult {
-        private boolean isOptedOut;
+        private final boolean isOptedOut;
         //can be null if isOptedOut is false!
-        private Instant time;
+        private final Instant time;
 
         //providedTime can be null if isOptedOut is false!
         GlobalOptoutResult(boolean providedIsOptedOut, Instant providedTime)

--- a/src/main/java/com/uid2/operator/util/Tuple.java
+++ b/src/main/java/com/uid2/operator/util/Tuple.java
@@ -8,7 +8,7 @@ public class Tuple {
         public Tuple2(T1 item1, T2 item2) {
             assert item1 != null;
             assert item2 != null;
-            
+
             this.item1 = item1;
             this.item2 = item2;
         }

--- a/src/main/java/com/uid2/operator/util/Tuple.java
+++ b/src/main/java/com/uid2/operator/util/Tuple.java
@@ -6,6 +6,9 @@ public class Tuple {
         private final T2 item2;
 
         public Tuple2(T1 item1, T2 item2) {
+            assert item1 != null;
+            assert item2 != null;
+            
             this.item1 = item1;
             this.item2 = item2;
         }
@@ -31,6 +34,10 @@ public class Tuple {
         private final T3 item3;
 
         public Tuple3(T1 item1, T2 item2, T3 item3) {
+            assert item1 != null;
+            assert item2 != null;
+            assert item3 != null;
+
             this.item1 = item1;
             this.item2 = item2;
             this.item3 = item3;

--- a/src/main/java/com/uid2/operator/util/Tuple.java
+++ b/src/main/java/com/uid2/operator/util/Tuple.java
@@ -6,9 +6,6 @@ public class Tuple {
         private final T2 item2;
 
         public Tuple2(T1 item1, T2 item2) {
-            assert item1 != null;
-            assert item2 != null;
-
             this.item1 = item1;
             this.item2 = item2;
         }
@@ -34,10 +31,6 @@ public class Tuple {
         private final T3 item3;
 
         public Tuple3(T1 item1, T2 item2, T3 item3) {
-            assert item1 != null;
-            assert item2 != null;
-            assert item3 != null;
-
             this.item1 = item1;
             this.item2 = item2;
             this.item3 = item3;

--- a/src/test/java/com/uid2/operator/UIDOperatorServiceTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorServiceTest.java
@@ -309,11 +309,12 @@ public class UIDOperatorServiceTest {
         assertNotNull(tokens);
     }
 
-    //UID2 uses v2 tokens but v2 doesn't handle phone number type correctly
-    //so passing in a phone number and it will be casted as an email type in UserIdentity
+    //UID2 uses v2 tokens but v2 doesn't handle phone number IdentityType correctly
+    //so passing in a phone number and it will be still casted as an email type in UserIdentity
     //and UserIdentity won't match to the default UIDOperatorService.testAlwaysOptInIdentityForPhone
+    //as the IdentityType won't match
     //will only test when we switch to v4 token
-    //this works for EUID because EUID is on v3 token already
+    //this works for EUID because EUID is on v3 token already which persists to correct IdentityType
     @ParameterizedTest
     @CsvSource({"email,optout@email.com,UID2", "email,optout@email.com,EUID", "phone,+00000000000,EUID"})
     public void testSpecialIdentityOptOutTokenRefresh(String type, String id, IdentityScope scope) {

--- a/src/test/java/com/uid2/operator/UIDOperatorServiceTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorServiceTest.java
@@ -260,8 +260,8 @@ public class UIDOperatorServiceTest {
 
     //UID2-1224
     @ParameterizedTest
-    @CsvSource({"email,optout@email.com", "phone,+00000000000"})
-    public void testSpecialIdentityOptOutTokenGenerate(String type, String id) {
+    @CsvSource({"email,optout@email.com,UID2", "email,optout@email.com,EUID", "phone,+00000000000,EUID"})
+    public void testSpecialIdentityOptOutTokenGenerate(String type, String id, IdentityScope scope) {
         InputUtil.InputVal inputVal;
         if(type.equals("email"))
         {
@@ -276,10 +276,16 @@ public class UIDOperatorServiceTest {
 
         final IdentityRequest identityRequest = new IdentityRequest(
                 new PublisherIdentity(123, 124, 125),
-                inputVal.toUserIdentity(IdentityScope.UID2, 0, this.now),
+                inputVal.toUserIdentity(scope, 0, this.now),
                 TokenGeneratePolicy.RespectOptOut
         );
-        final IdentityTokens tokens = uid2Service.generateIdentity(identityRequest);
+        IdentityTokens tokens;
+        if(scope == IdentityScope.EUID) {
+            tokens = euidService.generateIdentity(identityRequest);
+        }
+        else {
+            tokens = uid2Service.generateIdentity(identityRequest);
+        }
         assertEquals(tokens, IdentityTokens.LogoutToken);
     }
 


### PR DESCRIPTION
1.  Always enforce the special identities optout/optin status regardless what the optout store would state. 
2. This enforcement applied to token/generate, token/client-generate and token/refresh
3. All optout check goes thru UID2OperatorService.hasGlobalOptOut so the special identities like above are handled in this method now