### PR TITLE
Syw UID2-1224 special email opt out handling

### DIFF
--- a/src/main/java/com/uid2/operator/service/UIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/UIDOperatorService.java
@@ -85,7 +85,7 @@ public class UIDOperatorService implements IUIDOperatorService {
                 request.userIdentity.identityScope, request.userIdentity.identityType, firstLevelHash, request.userIdentity.privacyBits,
                 request.userIdentity.establishedAt, request.userIdentity.refreshedAt);
 
-        if (request.shouldCheckOptOut() && hasGlobalOptOut(firstLevelHashIdentity).isOptedOut()) {
+        if (request.shouldCheckOptOut() && getGlobalOptOutResult(firstLevelHashIdentity).isOptedOut()) {
             return IdentityTokens.LogoutToken;
         } else {
             return generateIdentity(request.publisherIdentity, firstLevelHashIdentity);
@@ -108,7 +108,7 @@ public class UIDOperatorService implements IUIDOperatorService {
         }
 
         try {
-            final GlobalOptoutResult logoutEntry = hasGlobalOptOut(token.userIdentity);
+            final GlobalOptoutResult logoutEntry = getGlobalOptOutResult(token.userIdentity);
             boolean optedOut = logoutEntry.isOptedOut();
 
             if (!optedOut || token.userIdentity.establishedAt.isAfter(logoutEntry.getTime())) {
@@ -125,7 +125,7 @@ public class UIDOperatorService implements IUIDOperatorService {
     @Override
     public MappedIdentity mapIdentity(MapRequest request) {
         final UserIdentity firstLevelHashIdentity = getFirstLevelHashIdentity(request.userIdentity, request.asOf);
-        if (request.shouldCheckOptOut() && hasGlobalOptOut(firstLevelHashIdentity).isOptedOut()) {
+        if (request.shouldCheckOptOut() && getGlobalOptOutResult(firstLevelHashIdentity).isOptedOut()) {
             return MappedIdentity.LogoutIdentity;
         } else {
             return getAdvertisingId(firstLevelHashIdentity, request.asOf);
@@ -256,7 +256,7 @@ public class UIDOperatorService implements IUIDOperatorService {
         }
     }
 
-    private GlobalOptoutResult hasGlobalOptOut(UserIdentity userIdentity) {
+    private GlobalOptoutResult getGlobalOptOutResult(UserIdentity userIdentity) {
         if (userIdentity.matches(testOptOutIdentityForEmail) || userIdentity.matches(testOptOutIdentityForPhone)) {
             return new GlobalOptoutResult(Instant.now());
         }

--- a/src/test/java/com/uid2/operator/UIDOperatorServiceTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorServiceTest.java
@@ -1,6 +1,7 @@
 package com.uid2.operator;
 
 import com.uid2.operator.model.*;
+import com.uid2.operator.service.EncodingUtils;
 import com.uid2.operator.service.EncryptedTokenEncoder;
 import com.uid2.operator.service.InputUtil;
 import com.uid2.operator.service.UIDOperatorService;
@@ -16,6 +17,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -253,4 +257,134 @@ public class UIDOperatorServiceTest {
         assertNotNull(mappedIdentityShouldBeOptOut);
         assertTrue(mappedIdentityShouldBeOptOut.isOptedOut());
     }
+
+    private enum TestIdentityInputType {
+        Email(0),
+        Phone(1),
+        EmailHash(2),
+        PhoneHash(3);
+
+        public final int type;
+
+        TestIdentityInputType(int type) { this.type = type; }
+    }
+
+    private InputUtil.InputVal generateInputVal(TestIdentityInputType type, String id) {
+        InputUtil.InputVal inputVal;
+        switch(type) {
+            case Email:
+                inputVal = InputUtil.normalizeEmail(id);
+                break;
+            case Phone:
+                inputVal = InputUtil.normalizePhone(id);
+                break;
+            case EmailHash:
+                inputVal = InputUtil.normalizeEmailHash(EncodingUtils.getSha256(id));
+                break;
+            default: //PhoneHash
+                inputVal = InputUtil.normalizePhoneHash(EncodingUtils.getSha256(id));
+        }
+        return inputVal;
+    }
+
+
+    //UID2-1224
+    @ParameterizedTest
+    @CsvSource({"Email,optout@email.com,UID2",
+            "EmailHash,optout@email.com,UID2",
+            "Email,optout@email.com,EUID",
+            "EmailHash,optout@email.com,EUID",
+            "Phone,+00000000000,EUID",
+            "PhoneHash,+00000000000,EUID"})
+    public void testSpecialIdentityOptOutTokenGenerate(TestIdentityInputType type, String id, IdentityScope scope) {
+        InputUtil.InputVal inputVal = generateInputVal(type, id);
+
+        //make sure this still works without optout record
+        when(this.optOutStore.getLatestEntry(any())).thenReturn(null);
+
+        final IdentityRequest identityRequest = new IdentityRequest(
+                new PublisherIdentity(123, 124, 125),
+                inputVal.toUserIdentity(scope, 0, this.now),
+                TokenGeneratePolicy.RespectOptOut
+        );
+        IdentityTokens tokens;
+        if(scope == IdentityScope.EUID) {
+            tokens = euidService.generateIdentity(identityRequest);
+        }
+        else {
+            tokens = uid2Service.generateIdentity(identityRequest);
+        }
+        assertEquals(tokens, IdentityTokens.LogoutToken);
+    }
+
+    //UID2 uses v2 tokens but v2 doesn't handle phone number IdentityType correctly
+    //so passing in a phone number and it will be still casted as an email type in UserIdentity
+    //and UserIdentity won't match to the default UIDOperatorService.testAlwaysOptInIdentityForPhone
+    //as the IdentityType won't match
+    //will only test when we switch to v4 token
+    //this works for EUID because EUID is on v3 token already which persists to correct IdentityType
+    @ParameterizedTest
+    @CsvSource({"Email,optout@email.com,UID2",
+            "EmailHash,optout@email.com,UID2",
+            "Email,optout@email.com,EUID",
+            "EmailHash,optout@email.com,EUID",
+            "Phone,+00000000000,EUID",
+            "PhoneHash,+00000000000,EUID"})
+    public void testSpecialIdentityOptOutTokenRefresh(TestIdentityInputType type, String id, IdentityScope scope) {
+        InputUtil.InputVal inputVal = generateInputVal(type, id);
+
+        final IdentityRequest identityRequest = new IdentityRequest(
+                new PublisherIdentity(123, 124, 125),
+                inputVal.toUserIdentity(scope, 0, this.now),
+                TokenGeneratePolicy.JustGenerate
+        );
+        IdentityTokens tokens;
+        if(scope == IdentityScope.EUID) {
+            tokens = euidService.generateIdentity(identityRequest);
+        }
+        else {
+            tokens = uid2Service.generateIdentity(identityRequest);
+        }
+        assertNotNull(tokens);
+
+        //make sure this still works even without optout record
+        when(this.optOutStore.getLatestEntry(any())).thenReturn(null);
+
+        final RefreshToken refreshToken = this.tokenEncoder.decodeRefreshToken(tokens.getRefreshToken());
+        assertEquals(RefreshResponse.Optout, (scope == IdentityScope.EUID? euidService: uid2Service).refreshIdentity(refreshToken));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"Email,blah@unifiedid.com,UID2",
+            "EmailHash,blah@unifiedid.com,UID2",
+            "Phone,+61401234567,EUID",
+            "PhoneHash,+61401234567,EUID",
+            "Email,blah@unifiedid.com,EUID",
+            "EmailHash,blah@unifiedid.com,EUID"})
+    public void testNormalIdentityOptIn(TestIdentityInputType type, String id, IdentityScope scope) {
+        InputUtil.InputVal inputVal = generateInputVal(type, id);
+        final IdentityRequest identityRequest = new IdentityRequest(
+                new PublisherIdentity(123, 124, 125),
+                inputVal.toUserIdentity(scope, 0, this.now),
+                TokenGeneratePolicy.JustGenerate
+        );
+        IdentityTokens tokens;
+        if(scope == IdentityScope.EUID) {
+            tokens = euidService.generateIdentity(identityRequest);
+        }
+        else {
+            tokens = uid2Service.generateIdentity(identityRequest);
+        }
+        assertNotEquals(tokens, IdentityTokens.LogoutToken);
+        assertNotNull(tokens);
+
+        final RefreshToken refreshToken = this.tokenEncoder.decodeRefreshToken(tokens.getRefreshToken());
+        RefreshResponse refreshResponse = (scope == IdentityScope.EUID? euidService: uid2Service).refreshIdentity(refreshToken);
+        assertTrue(refreshResponse.isRefreshed());
+        assertNotNull(refreshResponse.getTokens());
+        assertNotEquals(RefreshResponse.Optout, refreshResponse);
+    }
+
+
+
 }


### PR DESCRIPTION
- Always enforce the special identities optout/optin status regardless what the optout store would state.
- This enforcement applied to token/generate, token/client-generate and token/refresh
- All optout check goes thru UID2OperatorService.hasGlobalOptOut so the special identities like above are handled in this method now