### PR TITLE
Set GCP OIDC enclave service instances to 12

### DIFF
--- a/scripts/gcp-oidc/conf/default-config.json
+++ b/scripts/gcp-oidc/conf/default-config.json
@@ -1,6 +1,6 @@
 {
   "service_verbose": true,
-  "service_instances": 16,
+  "service_instances": 12,
   "core_s3_bucket": null,
   "core_attest_url": null,
   "core_api_token": null,


### PR DESCRIPTION
 to reserve some CPU resources for background jobs