### PR TITLE
Push image to GCP Registry

### DIFF
--- a/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
+++ b/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
@@ -145,18 +145,12 @@ jobs:
             JAR_VERSION=${{ steps.version.outputs.new_version }}
             IMAGE_VERSION=${{ steps.version.outputs.new_version }}
 
-      - name: Auth GCP
-        id: auth-gcp
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: '${{ secrets.GCP_REGISTRY_CREDENTIAL }}'
-
-      - name: Login GCP Registry
+      - name: Login to GCP Registry
         uses: docker/login-action@v1
         with:
           registry: us-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.auth-gcp.outputs.access_token }}
+          username: _json_key
+          password: ${{ secrets.GCP_REGISTRY_CREDENTIAL }}
 
       - name: Extract metadata (tags, labels) for GCP
         id: meta-gcp

--- a/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
+++ b/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
@@ -18,6 +18,7 @@ on:
       
 env:
   REGISTRY: ghcr.io
+  GCP_REGISTRY: us-docker.pkg.dev
   MAVEN_PROFILE: gcp
   ENCLAVE_PROTOCOL: gcp-oidc
   IMAGE_NAME: ${{ github.repository }}
@@ -144,3 +145,35 @@ jobs:
             JAR_VERSION=${{ steps.version.outputs.new_version }}
             IMAGE_VERSION=${{ steps.version.outputs.new_version }}
 
+      - name: Auth GCP
+        id: auth-gcp
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_REGISTRY_CREDENTIAL }}'
+
+      - name: Login GCP Registry
+        uses: docker/login-action@v1
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth-gcp.outputs.access_token }}
+
+      - name: Extract metadata (tags, labels) for GCP
+        id: meta-gcp
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.new_version }}-${{ env.ENCLAVE_PROTOCOL }}
+            type=raw,value=${{ inputs.tag }}
+
+      - name: Push to GCP Registry
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ env.DOCKER_CONTEXT_PATH }}
+          push: true
+          tags: ${{ steps.meta-gcp.outputs.tags }}
+          labels: ${{ steps.meta-gcp.outputs.labels }}
+          build-args: |
+            JAR_VERSION=${{ steps.version.outputs.new_version }}
+            IMAGE_VERSION=${{ steps.version.outputs.new_version }}

--- a/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
+++ b/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
@@ -19,6 +19,7 @@ on:
 env:
   REGISTRY: ghcr.io
   GCP_REGISTRY: us-docker.pkg.dev
+  GCP_PROJECT: uid2-test
   MAVEN_PROFILE: gcp
   ENCLAVE_PROTOCOL: gcp-oidc
   IMAGE_NAME: ${{ github.repository }}
@@ -156,7 +157,7 @@ jobs:
         id: meta-gcp
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ steps.version.outputs.new_version }}-${{ env.ENCLAVE_PROTOCOL }}
             type=raw,value=${{ inputs.tag }}

--- a/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
+++ b/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
@@ -97,9 +97,18 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.new_version }}-${{ env.ENCLAVE_PROTOCOL }}
+            type=raw,value=${{ inputs.tag }}
+
+      - name: Extract metadata (tags, labels) for all Docker images
+        id: meta-all
+        uses: docker/metadata-action@v4
+        with:
           images: |
-            name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},enable=true
-            name=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/${{ env.IMAGE_NAME }},enable=true
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ steps.version.outputs.new_version }}-${{ env.ENCLAVE_PROTOCOL }}
             type=raw,value=${{ inputs.tag }}
@@ -109,8 +118,8 @@ jobs:
         with:
           context: ${{ env.DOCKER_CONTEXT_PATH }}
           load: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-all.outputs.tags }}
+          labels: ${{ steps.meta-all.outputs.labels }}
           build-args: |
             JAR_VERSION=${{ steps.version.outputs.new_version }}
             IMAGE_VERSION=${{ steps.version.outputs.new_version }}
@@ -149,8 +158,8 @@ jobs:
         with:
           context: ${{ env.DOCKER_CONTEXT_PATH }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-all.outputs.tags }}
+          labels: ${{ steps.meta-all.outputs.labels }}
           build-args: |
             JAR_VERSION=${{ steps.version.outputs.new_version }}
             IMAGE_VERSION=${{ steps.version.outputs.new_version }}

--- a/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
+++ b/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
@@ -147,7 +147,7 @@ jobs:
             IMAGE_VERSION=${{ steps.version.outputs.new_version }}
 
       - name: Login to GCP Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: us-docker.pkg.dev
           username: _json_key

--- a/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
+++ b/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
@@ -86,11 +86,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to the GCP Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.GCP_REGISTRY }}
+          username: _json_key
+          password: ${{ secrets.GCP_REGISTRY_CREDENTIAL }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: |
+            name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},enable=true
+            name=${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/${{ env.IMAGE_NAME }},enable=true
           tags: |
             type=raw,value=${{ steps.version.outputs.new_version }}-${{ env.ENCLAVE_PROTOCOL }}
             type=raw,value=${{ inputs.tag }}
@@ -142,33 +151,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            JAR_VERSION=${{ steps.version.outputs.new_version }}
-            IMAGE_VERSION=${{ steps.version.outputs.new_version }}
-
-      - name: Login to GCP Registry
-        uses: docker/login-action@v2
-        with:
-          registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GCP_REGISTRY_CREDENTIAL }}
-
-      - name: Extract metadata (tags, labels) for GCP
-        id: meta-gcp
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.GCP_REGISTRY }}/${{ env.GCP_PROJECT }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=${{ steps.version.outputs.new_version }}-${{ env.ENCLAVE_PROTOCOL }}
-            type=raw,value=${{ inputs.tag }}
-
-      - name: Push to GCP Registry
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ env.DOCKER_CONTEXT_PATH }}
-          push: true
-          tags: ${{ steps.meta-gcp.outputs.tags }}
-          labels: ${{ steps.meta-gcp.outputs.labels }}
           build-args: |
             JAR_VERSION=${{ steps.version.outputs.new_version }}
             IMAGE_VERSION=${{ steps.version.outputs.new_version }}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.8.33-SNAPSHOT</version>
+    <version>5.8.13-20f23891c9</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.8.31-SNAPSHOT</version>
+    <version>5.8.33-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Changes
* Push Docker image to both GitHub Registry and GCP Registry, they use the same image digest. It means when create a new enclave ID, you can still go to the GitHub packages page to find the digest.
* Currently it uses test project, should switch to production once it's ready