### PR TITLE
change terraform variables: env and machine type

### DIFF
--- a/scripts/gcp-oidc/terraform/README.md
+++ b/scripts/gcp-oidc/terraform/README.md
@@ -68,9 +68,8 @@ terraform destroy
 | service_account_name      | `string` | n/a                  |   yes    | n/a                                                                                               |
 | uid_operator_image        | `string` | n/a                  |   yes    | n/a                                                                                               |
 | uid_api_token             | `string` | n/a                  |   yes    | n/a                                                                                               |
+| uid_deployment_env        | `string` | n/a                  |   yes    | Allowed values: `"integ"`, `"prod"`                                                               |
 | uid_api_token_secret_name | `string` | `"secret-api-token"` |    no    | n/a                                                                                               |
-| uid_machine_type          | `string` | `"n2d-standard-16"`  |    no    | n/a                                                                                               |
-| uid_deployment_env        | `string` | `"integ"`            |    no    | n/a                                                                                               |
 | region                    | `string` | `"us-east1"`         |    no    | n/a                                                                                               |
 | network_name              | `string` | `"uid-operator"`     |    no    | n/a                                                                                               |
 | max_replicas              | `number` | `5`                  |    no    | n/a                                                                                               |

--- a/scripts/gcp-oidc/terraform/main.tf
+++ b/scripts/gcp-oidc/terraform/main.tf
@@ -80,7 +80,7 @@ module "secret-manager" {
 
 resource "google_compute_instance_template" "uid_operator" {
   name_prefix  = "uid-operator-cs-template-"
-  machine_type = var.uid_machine_type
+  machine_type = var.uid_deployment_env == "prod" ? "n2d-standard-16" : "n2d-standard-2"
 
   tags = [var.network_name]
 

--- a/scripts/gcp-oidc/terraform/variables.tf
+++ b/scripts/gcp-oidc/terraform/variables.tf
@@ -16,18 +16,17 @@ variable "service_account_name" {
   type = string
 }
 
-variable "uid_machine_type" {
-  type    = string
-  default = "n2d-standard-16"
-}
-
 variable "uid_operator_image" {
   type = string
 }
 
 variable "uid_deployment_env" {
-  type    = string
-  default = "integ"
+  type = string
+
+  validation {
+    condition     = contains(["integ", "prod"], var.uid_deployment_env)
+    error_message = "Allowed values for uid_deployment_env are \"integ\" or \"prod\"."
+  }
 }
 
 variable "uid_api_token" {


### PR DESCRIPTION
- Make `uid_deployment_env` a required input.
- Remove `uid_machine_type` input, it will be decided based on `uid_deployment_env`
