### PR TITLE
Return opted out token on CSTG refresh

### DIFF
--- a/src/main/java/com/uid2/operator/service/UIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/UIDOperatorService.java
@@ -21,6 +21,9 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 
+import static com.uid2.operator.IdentityConst.ClientSideTokenGenerateOptOutIdentityForEmail;
+import static com.uid2.operator.IdentityConst.ClientSideTokenGenerateOptOutIdentityForPhone;
+
 public class UIDOperatorService implements IUIDOperatorService {
     public static final String IDENTITY_TOKEN_EXPIRES_AFTER_SECONDS = "identity_token_expires_after_seconds";
     public static final String REFRESH_TOKEN_EXPIRES_AFTER_SECONDS = "refresh_token_expires_after_seconds";
@@ -107,26 +110,58 @@ public class UIDOperatorService implements IUIDOperatorService {
             return RefreshResponse.Deprecated;
         }
 
-        if (token.expiresAt.isBefore(Instant.now(this.clock))) {
+        final Instant now = clock.instant();
+
+        if (token.expiresAt.isBefore(now)) {
             return RefreshResponse.Expired;
         }
 
+        final PrivacyBits privacyBits = PrivacyBits.fromInt(token.userIdentity.privacyBits);
+        final boolean isCstg = privacyBits.isClientSideTokenGenerated();
+
         try {
             final GlobalOptoutResult logoutEntry = getGlobalOptOutResult(token.userIdentity);
-            boolean optedOut = logoutEntry.isOptedOut();
+            final boolean optedOut = logoutEntry.isOptedOut();
+
+            final Duration durationSinceLastRefresh = Duration.between(token.createdAt, now);
 
             if (!optedOut || token.userIdentity.establishedAt.isAfter(logoutEntry.getTime())) {
-                Duration durationSinceLastRefresh = Duration.between(token.createdAt, Instant.now(this.clock));
                 IdentityTokens identityTokens = this.generateIdentity(token.publisherIdentity, token.userIdentity);
-                boolean isCstg = PrivacyBits.fromInt(token.userIdentity.privacyBits).isClientSideTokenGenerated();
 
                 return RefreshResponse.createRefreshedResponse(identityTokens, durationSinceLastRefresh, isCstg);
+            } else if (isCstg) {
+                // The user has opted out after the userIdentity was established.
+                privacyBits.setClientSideTokenGenerateOptout();
+
+                final UserIdentity cstgOptOutIdentity = getClientSideTokenGenerateOptOutInputVal(token.userIdentity.identityType)
+                        .toUserIdentity(identityScope, privacyBits.getAsInt(), now);
+
+                final IdentityTokens identityTokens = generateIdentity(
+                        new IdentityRequest(
+                                new PublisherIdentity(token.publisherIdentity.siteId, 0, 0),
+                                cstgOptOutIdentity, OptoutCheckPolicy.DoNotRespect));
+
+                return RefreshResponse.createRefreshedResponse(identityTokens, durationSinceLastRefresh, true);
             } else {
                 return RefreshResponse.Optout;
             }
         } catch (Exception ex) {
             return RefreshResponse.Invalid;
         }
+    }
+
+    private static InputUtil.InputVal getClientSideTokenGenerateOptOutInputVal(IdentityType identityType) {
+        switch (identityType) {
+            case Email:
+                return InputUtil.InputVal.validEmail(
+                        ClientSideTokenGenerateOptOutIdentityForEmail,
+                        ClientSideTokenGenerateOptOutIdentityForEmail);
+            case Phone:
+                return InputUtil.InputVal.validPhone(
+                        ClientSideTokenGenerateOptOutIdentityForPhone,
+                        ClientSideTokenGenerateOptOutIdentityForPhone);
+        }
+        throw new IllegalArgumentException("Invalid identity type " + identityType);
     }
 
     @Override

--- a/src/main/java/com/uid2/operator/service/UIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/UIDOperatorService.java
@@ -160,8 +160,14 @@ public class UIDOperatorService implements IUIDOperatorService {
                 return InputUtil.InputVal.validPhone(
                         ClientSideTokenGenerateOptOutIdentityForPhone,
                         ClientSideTokenGenerateOptOutIdentityForPhone);
+            default:
+                // Assert will fire when this code path is hit by a test.
+                assert false: "Invalid identity type " + identityType;
+                // Provide a fallback value instead of throwing an exception.
+                return InputUtil.InputVal.validEmail(
+                        ClientSideTokenGenerateOptOutIdentityForEmail,
+                        ClientSideTokenGenerateOptOutIdentityForEmail);
         }
-        throw new IllegalArgumentException("Invalid identity type " + identityType);
     }
 
     @Override

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -3363,36 +3363,28 @@ public class UIDOperatorVerticleTest {
     }
 
     private void assertAreClientSideGeneratedTokens(AdvertisingToken advertisingToken, RefreshToken refreshToken, int siteId, IdentityType identityType, String identity) {
-        final PrivacyBits advertisingTokenPrivacyBits = PrivacyBits.fromInt(advertisingToken.userIdentity.privacyBits);
-        final PrivacyBits refreshTokenPrivacyBits = PrivacyBits.fromInt(refreshToken.userIdentity.privacyBits);
-
-        final byte[] advertisingId = getAdvertisingIdFromIdentity(identityType,
+        assertAreClientSideGeneratedTokens(advertisingToken,
+                refreshToken,
+                siteId,
+                identityType,
                 identity,
-                firstLevelSalt,
-                rotatingSalt123.getSalt());
-
-        final byte[] firstLevelHash = TokenUtils.getFirstLevelHashFromIdentity(identity, firstLevelSalt);
-
-        assertAll(
-                () -> assertTrue(advertisingTokenPrivacyBits.isClientSideTokenGenerated(), "Advertising token privacy bits CSTG flag is incorrect"),
-                () -> assertFalse(advertisingTokenPrivacyBits.isClientSideTokenOptedOut(), "Advertising token privacy bits CSTG optout flag is incorrect"),
-
-                () -> assertTrue(refreshTokenPrivacyBits.isClientSideTokenGenerated(), "Refresh token privacy bits CSTG flag is incorrect"),
-                () -> assertFalse(refreshTokenPrivacyBits.isClientSideTokenOptedOut(), "Refresh token privacy bits CSTG optout flag is incorrect"),
-
-                () -> assertEquals(siteId, advertisingToken.publisherIdentity.siteId, "Advertising token site ID is incorrect"),
-                () -> assertEquals(siteId, refreshToken.publisherIdentity.siteId, "Refresh token site ID is incorrect"),
-
-                () -> assertArrayEquals(advertisingId, advertisingToken.userIdentity.id, "Advertising token ID is incorrect"),
-                () -> assertArrayEquals(firstLevelHash, refreshToken.userIdentity.id, "Refresh token ID is incorrect")
-        );
+                false);
     }
 
     private void assertAreClientSideGeneratedOptOutTokens(AdvertisingToken advertisingToken, RefreshToken refreshToken, int siteId, IdentityType identityType) {
+        final String identity = getClientSideGeneratedTokenOptOutIdentity(identityType);
+
+        assertAreClientSideGeneratedTokens(advertisingToken,
+                refreshToken,
+                siteId,
+                identityType,
+                identity,
+                true);
+    }
+
+    private void assertAreClientSideGeneratedTokens(AdvertisingToken advertisingToken, RefreshToken refreshToken, int siteId, IdentityType identityType, String identity, boolean expectedOptOut) {
         final PrivacyBits advertisingTokenPrivacyBits = PrivacyBits.fromInt(advertisingToken.userIdentity.privacyBits);
         final PrivacyBits refreshTokenPrivacyBits = PrivacyBits.fromInt(refreshToken.userIdentity.privacyBits);
-
-        final String identity = getClientSideGeneratedTokenOptOutIdentity(identityType);
 
         final byte[] advertisingId = getAdvertisingIdFromIdentity(identityType,
                 identity,
@@ -3403,10 +3395,10 @@ public class UIDOperatorVerticleTest {
 
         assertAll(
                 () -> assertTrue(advertisingTokenPrivacyBits.isClientSideTokenGenerated(), "Advertising token privacy bits CSTG flag is incorrect"),
-                () -> assertTrue(advertisingTokenPrivacyBits.isClientSideTokenOptedOut(), "Advertising token privacy bits CSTG optout flag is incorrect"),
+                () -> assertEquals(expectedOptOut, advertisingTokenPrivacyBits.isClientSideTokenOptedOut(), "Advertising token privacy bits CSTG optout flag is incorrect"),
 
                 () -> assertTrue(refreshTokenPrivacyBits.isClientSideTokenGenerated(), "Refresh token privacy bits CSTG flag is incorrect"),
-                () -> assertTrue(refreshTokenPrivacyBits.isClientSideTokenOptedOut(), "Refresh token privacy bits CSTG optout flag is incorrect"),
+                () -> assertEquals(expectedOptOut, refreshTokenPrivacyBits.isClientSideTokenOptedOut(), "Refresh token privacy bits CSTG optout flag is incorrect"),
 
                 () -> assertEquals(siteId, advertisingToken.publisherIdentity.siteId, "Advertising token site ID is incorrect"),
                 () -> assertEquals(siteId, refreshToken.publisherIdentity.siteId, "Refresh token site ID is incorrect"),


### PR DESCRIPTION
If a user has opted out after token generation, we should return an opted out token upon refresh.