### PR TITLE
wait before error quit

### DIFF
--- a/src/main/java/com/uid2/operator/Main.java
+++ b/src/main/java/com/uid2/operator/Main.java
@@ -194,12 +194,23 @@ public class Main {
                 return;
             }
 
+            boolean errorQuit = false;
+
             try {
                 Main app = new Main(vertx, ar.result());
                 app.run();
             } catch (Exception e) {
                 LOGGER.error("Error: " + e.getMessage(), e);
-                ((LoggerContext)org.slf4j.LoggerFactory.getILoggerFactory()).stop(); // flush logs before shutdown
+                errorQuit = true;
+            }
+
+            if(errorQuit){
+                // allow log to be flushed before quit app.
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    // swallow
+                }
                 vertx.close();
                 System.exit(1);
             }


### PR DESCRIPTION
Wait a bit before error quit. Allow error log to be flushed to logs.

`((LoggerContext)org.slf4j.LoggerFactory.getILoggerFactory()).stop();` does not always work - it depends on OS buffer implementation.

This is a known issue: https://jira.qos.ch/browse/LOGBACK-735

Without this fix we will see weird log truncation in GCP. The real exception will not be logged - not friendly for touble shooting.

<img width="1095" alt="image" src="https://github.com/IABTechLab/uid2-operator/assets/137876002/67e6437c-bc05-45f5-94f4-8ca4a50bf636">


