### PR TITLE
Fix status codes

### DIFF
--- a/src/main/java/com/uid2/operator/service/EncryptedTokenEncoder.java
+++ b/src/main/java/com/uid2/operator/service/EncryptedTokenEncoder.java
@@ -121,6 +121,10 @@ public class EncryptedTokenEncoder implements ITokenEncoder {
         final int keyId = b.getInt(2);
         final KeysetKey key = this.keyManager.getKey(keyId);
 
+        if (key == null) {
+            throw new ClientInputValidationException("Failed to fetch key with id: " + keyId);
+        }
+
         final byte[] decryptedPayload = AesGcm.decrypt(bytes, 6, key);
 
         final Buffer b2 = Buffer.buffer(decryptedPayload);

--- a/src/main/java/com/uid2/operator/service/V2RequestUtil.java
+++ b/src/main/java/com/uid2/operator/service/V2RequestUtil.java
@@ -120,7 +120,7 @@ public class V2RequestUtil {
             //  byte 5-N: IV + encrypted body + GCM AUTH TAG
             bytes = Utils.decodeBase64String(bodyString);
         }
-        catch (ClientInputValidationException ex) {
+        catch (IllegalArgumentException ex) {
             return new V2Request("Invalid body: Body is not valid base64.");
         }
 


### PR DESCRIPTION
This PR fixes some mismatches that arose from https://github.com/IABTechLab/uid2-operator/pull/259
- Catch `IllegalArgumentException` in `parseRefreshRequest`
- Throw `ClientInputValidationException` in `decodeRefreshTokenV3` when `this.keyManager.getKey(keyId)` returns null. Also log out the `keyId`