### PR TITLE
[UID2-2204] Ignore policy param for identity/map

### DIFF
--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -93,7 +93,6 @@ public class UIDOperatorVerticle extends AbstractVerticle {
     private final Map<Tuple.Tuple2<String, Boolean>, DistributionSummary> _refreshDurationMetricSummaries = new HashMap<>();
     private final Map<Tuple.Tuple3<String, Boolean, Boolean>, Counter> _advertisingTokenExpiryStatus = new HashMap<>();
     private final Map<Tuple.Tuple3<String, OptoutCheckPolicy, String>, Counter> _tokenGeneratePolicyCounters = new HashMap<>();
-    private final Map<Tuple.Tuple3<String, OptoutCheckPolicy, String>, Counter> _identityMapPolicyCounters = new HashMap<>();
     private final Map<String, Tuple.Tuple2<Counter, Counter>> _identityMapUnmappedIdentifiers = new HashMap<>();
     private final Map<String, Counter> _identityMapRequestWithUnmapped = new HashMap<>();
     private final IdentityScope identityScope;
@@ -1654,13 +1653,6 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                 .register(Metrics.globalRegistry)).increment();
     }
 
-    private void recordIdentityMapPolicy(String apiContact, OptoutCheckPolicy policy, String policyParameterKey) {
-        _identityMapPolicyCounters.computeIfAbsent(new Tuple.Tuple3<>(apiContact, policy, policyParameterKey), triple -> Counter
-                .builder("uid2.identity_map_policy_usage")
-                .description("Counter for identity map policy usage")
-                .tags("api_contact", triple.getItem1(), "policy", String.valueOf(triple.getItem2()), "policy_parameter", triple.getItem3())
-                .register(Metrics.globalRegistry)).increment();
-    }
 
     private TransparentConsentParseResult getUserConsentV2(JsonObject req) {
         final String rawTcString = req.getString("tcf_consent_string");

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -777,10 +777,11 @@ public class UIDOperatorVerticleTest {
         emails.add("test1@uid2.com");
         req.put("email", emails);
 
-        send("v2", vertx, "v2/identity/map", false, null, req, 400, respJson -> {
-            assertFalse(respJson.containsKey("body"));
-            assertEquals("client_error", respJson.getString("status"));
-            assertEquals("Required opt-out policy argument for identity/map is missing or not set to 1", respJson.getString("message"));
+        send("v2", vertx, "v2/identity/map", false, null, req, 200, respJson -> {
+            assertTrue(respJson.containsKey("body"));
+            assertFalse(respJson.containsKey("client_error"));
+//            assertEquals("client_error", respJson.getString("status"));
+//            assertEquals("Required opt-out policy argument for identity/map is missing or not set to 1", respJson.getString("message"));
             testContext.completeNow();
         });
     }
@@ -798,11 +799,14 @@ public class UIDOperatorVerticleTest {
         emails.add("test1@uid2.com");
         req.put("email", emails);
         req.put(policyParameterKey, OptoutCheckPolicy.DoNotRespect.policy);
+        // TODO
+        // ignore check for policy parameter i request body but always check identifiers for optout
 
-        send("v2", vertx, "v2/identity/map", false, null, req, 400, respJson -> {
-            assertFalse(respJson.containsKey("body"));
-            assertEquals("client_error", respJson.getString("status"));
-            assertEquals("Required opt-out policy argument for identity/map is missing or not set to 1", respJson.getString("message"));
+        send("v2", vertx, "v2/identity/map", false, null, req, 200, respJson -> {
+            assertTrue(respJson.containsKey("body"));
+            assertFalse(respJson.containsKey("client_error"));
+//            assertEquals("client_error", respJson.getString("status"));
+//            assertEquals("Required opt-out policy argument for identity/map is missing or not set to 1", respJson.getString("message"));
             testContext.completeNow();
         });
     }
@@ -2494,13 +2498,14 @@ public class UIDOperatorVerticleTest {
         JsonArray emails = new JsonArray();
         emails.add("random-optout-user@email.io");
         req.put("email", emails);
+        // TODO fix test
 
         send(apiVersion, vertx, apiVersion + "/identity/map", false, null, req, 200, json -> {
             try {
-                Assertions.assertTrue(json.getJsonObject("body").getJsonArray("unmapped") == null ||
-                        json.getJsonObject("body").getJsonArray("unmapped").isEmpty());
-                Assertions.assertEquals(1, json.getJsonObject("body").getJsonArray("mapped").size());
-                Assertions.assertEquals("random-optout-user@email.io", json.getJsonObject("body").getJsonArray("mapped").getJsonObject(0).getString("identifier"));
+//                Assertions.assertTrue(json.getJsonObject("body").getJsonArray("unmapped") == null ||
+//                        json.getJsonObject("body").getJsonArray("unmapped").isEmpty());
+//                Assertions.assertEquals(1, json.getJsonObject("body").getJsonArray("mapped").size());
+//                Assertions.assertEquals("random-optout-user@email.io", json.getJsonObject("body").getJsonArray("mapped").getJsonObject(0).getString("identifier"));
                 testContext.completeNow();
             } catch (Exception e) {
                 testContext.failNow(e);

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -765,52 +765,62 @@ public class UIDOperatorVerticleTest {
         }
     }
 
-    @Test
-    void identityMapNewClientNoPolicySpecified(Vertx vertx, VertxTestContext testContext) {
+    @ParameterizedTest
+    @ValueSource(strings = {"v1", "v2"})
+    void identityMapNewClientNoPolicySpecified(String apiVersion, Vertx vertx, VertxTestContext testContext) {
         final int clientSiteId = 201;
         fakeAuth(clientSiteId, newClientCreationDateTime, Role.MAPPER);
         setupSalts();
         setupKeys();
 
+        // the clock value shouldn't matter here
+        when(optOutStore.getLatestEntry(any(UserIdentity.class)))
+            .thenReturn(now.minus(1, ChronoUnit.HOURS));
+
         JsonObject req = new JsonObject();
         JsonArray emails = new JsonArray();
-        emails.add("test1@uid2.com");
+        emails.add("random-optout-user@email.io");
         req.put("email", emails);
 
-        send("v2", vertx, "v2/identity/map", false, null, req, 200, respJson -> {
+        send(apiVersion, vertx, apiVersion + "/identity/map", false, null, req, 200, respJson -> {
             assertTrue(respJson.containsKey("body"));
             assertFalse(respJson.containsKey("client_error"));
-            JsonArray mappedArr = respJson.getJsonObject("body").getJsonArray("mapped");
-            Assertions.assertEquals(1, mappedArr.size());
-            Assertions.assertEquals(emails.getString(0), mappedArr.getJsonObject(0).getString("identifier"));
+            JsonArray unmappedArr = respJson.getJsonObject("body").getJsonArray("unmapped");
+            Assertions.assertEquals(1, unmappedArr.size());
+            Assertions.assertEquals(emails.getString(0), unmappedArr.getJsonObject(0).getString("identifier"));
+            Assertions.assertEquals("optout", unmappedArr.getJsonObject(0).getString("reason"));
             testContext.completeNow();
         });
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"policy", "optout_check"})
-    void identityMapNewClientWrongPolicySpecified(String policyParameterKey, Vertx vertx, VertxTestContext testContext) {
+    @MethodSource("versionAndPolicy")
+    void identityMapNewClientWrongPolicySpecified(String apiVersion, String policyParameterKey, Vertx vertx, VertxTestContext testContext) {
         final int clientSiteId = 201;
         fakeAuth(clientSiteId, newClientCreationDateTime, Role.MAPPER);
         setupSalts();
         setupKeys();
-
+        // the clock value shouldn't matter here
+        when(optOutStore.getLatestEntry(any(UserIdentity.class)))
+            .thenReturn(now.minus(1, ChronoUnit.HOURS));
         JsonObject req = new JsonObject();
         JsonArray emails = new JsonArray();
-        emails.add("test1@uid2.com");
+        emails.add("random-optout-user@email.io");
         req.put("email", emails);
         req.put(policyParameterKey, OptoutCheckPolicy.DoNotRespect.policy);
 
-        send("v2", vertx, "v2/identity/map", false, null, req, 200, respJson -> {
+        send(apiVersion, vertx, apiVersion + "/identity/map", false, null, req, 200, respJson -> {
             assertTrue(respJson.containsKey("body"));
             assertFalse(respJson.containsKey("client_error"));
-            JsonArray mappedArr = respJson.getJsonObject("body").getJsonArray("mapped");
-            Assertions.assertEquals(1, mappedArr.size());
-            Assertions.assertEquals(emails.getString(0), mappedArr.getJsonObject(0).getString("identifier"));
+            JsonArray unmappedArr = respJson.getJsonObject("body").getJsonArray("unmapped");
+            Assertions.assertEquals(1, unmappedArr.size());
+            Assertions.assertEquals(emails.getString(0), unmappedArr.getJsonObject(0).getString("identifier"));
+            Assertions.assertEquals("optout", unmappedArr.getJsonObject(0).getString("reason"));
             testContext.completeNow();
         });
     }
 
+    @Deprecated // We don't need a test for different behavior of new vs legacy participants
     @Test
     void identityMapNewClientNoPolicySpecifiedOlderKeySuccessful(Vertx vertx, VertxTestContext testContext) {
         ClientKey newClientKey = new ClientKey(
@@ -843,6 +853,7 @@ public class UIDOperatorVerticleTest {
         JsonArray emails = new JsonArray();
         req.put("email", emails);
         emails.add("test1@uid2.com");
+        // policy parameter not passed but will still succeed as old participant
 
         send("v2", vertx, "v2/identity/map", false, null, req, 200, respJson -> {
             assertTrue(respJson.containsKey("body"));
@@ -851,6 +862,7 @@ public class UIDOperatorVerticleTest {
         });
     }
 
+    @Deprecated // We don't need a test for different behavior of new vs legacy participants
     @ParameterizedTest
     @ValueSource(strings = {"policy", "optout_check"})
     void identityMapNewClientWrongPolicySpecifiedOlderKeySuccessful(String policyParameterKey, Vertx vertx, VertxTestContext testContext) {
@@ -2626,7 +2638,7 @@ public class UIDOperatorVerticleTest {
         ClientSideKeypair keypair = new ClientSideKeypair(clientSideTokenGenerateSubscriptionId, clientSideTokenGeneratePublicKey, clientSideTokenGeneratePrivateKey, clientSideTokenGenerateSiteId, "", Instant.now(), false, "");
         when(clientSideKeypairProvider.getSnapshot()).thenReturn(clientSideKeypairSnapshot);
         when(clientSideKeypairSnapshot.getKeypair(clientSideTokenGenerateSubscriptionId)).thenReturn(keypair);
-        when(siteProvider.getSite(eq(clientSideTokenGenerateSiteId))).thenReturn(new Site(clientSideTokenGenerateSiteId, "test", true, new HashSet<>(List.of(domainNames))));
+        when(siteProvider.getSite(clientSideTokenGenerateSiteId)).thenReturn(new Site(clientSideTokenGenerateSiteId, "test", true, new HashSet<>(List.of(domainNames))));
     }
 
     //if no identity is provided will get an error

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -780,8 +780,9 @@ public class UIDOperatorVerticleTest {
         send("v2", vertx, "v2/identity/map", false, null, req, 200, respJson -> {
             assertTrue(respJson.containsKey("body"));
             assertFalse(respJson.containsKey("client_error"));
-//            assertEquals("client_error", respJson.getString("status"));
-//            assertEquals("Required opt-out policy argument for identity/map is missing or not set to 1", respJson.getString("message"));
+            JsonArray mappedArr = respJson.getJsonObject("body").getJsonArray("mapped");
+            Assertions.assertEquals(1, mappedArr.size());
+            Assertions.assertEquals(emails.getString(0), mappedArr.getJsonObject(0).getString("identifier"));
             testContext.completeNow();
         });
     }
@@ -799,14 +800,13 @@ public class UIDOperatorVerticleTest {
         emails.add("test1@uid2.com");
         req.put("email", emails);
         req.put(policyParameterKey, OptoutCheckPolicy.DoNotRespect.policy);
-        // TODO
-        // ignore check for policy parameter i request body but always check identifiers for optout
 
         send("v2", vertx, "v2/identity/map", false, null, req, 200, respJson -> {
             assertTrue(respJson.containsKey("body"));
             assertFalse(respJson.containsKey("client_error"));
-//            assertEquals("client_error", respJson.getString("status"));
-//            assertEquals("Required opt-out policy argument for identity/map is missing or not set to 1", respJson.getString("message"));
+            JsonArray mappedArr = respJson.getJsonObject("body").getJsonArray("mapped");
+            Assertions.assertEquals(1, mappedArr.size());
+            Assertions.assertEquals(emails.getString(0), mappedArr.getJsonObject(0).getString("identifier"));
             testContext.completeNow();
         });
     }
@@ -2498,14 +2498,15 @@ public class UIDOperatorVerticleTest {
         JsonArray emails = new JsonArray();
         emails.add("random-optout-user@email.io");
         req.put("email", emails);
-        // TODO fix test
 
         send(apiVersion, vertx, apiVersion + "/identity/map", false, null, req, 200, json -> {
             try {
-//                Assertions.assertTrue(json.getJsonObject("body").getJsonArray("unmapped") == null ||
-//                        json.getJsonObject("body").getJsonArray("unmapped").isEmpty());
-//                Assertions.assertEquals(1, json.getJsonObject("body").getJsonArray("mapped").size());
-//                Assertions.assertEquals("random-optout-user@email.io", json.getJsonObject("body").getJsonArray("mapped").getJsonObject(0).getString("identifier"));
+                Assertions.assertTrue(json.getJsonObject("body").getJsonArray("mapped") == null ||
+                        json.getJsonObject("body").getJsonArray("mapped").isEmpty());
+                JsonArray unmappedArr = json.getJsonObject("body").getJsonArray("unmapped");
+                Assertions.assertEquals(1, unmappedArr.size());
+                Assertions.assertEquals("random-optout-user@email.io", unmappedArr.getJsonObject(0).getString("identifier"));
+                Assertions.assertEquals("optout", unmappedArr.getJsonObject(0).getString("reason"));
                 testContext.completeNow();
             } catch (Exception e) {
                 testContext.failNow(e);


### PR DESCRIPTION
This PR affects POST `/v1/identity/map` and POST `/v2/identity/map` endpoints. For both 
- Ignore `policy` and `optout_check` parameters
- Enforece optout check on the identifiers and reply with identifier in unmapped section

### Note:
No changes to 

- GET `/v1/identity/map`
- GET `/identity/map` (Deprecated)

### Unit Testing

| Scenario | Result | Test Name | Endpoint |
|--------|--------|--------|--------|
| Request body contains optout or policy parameter | Ignore parameter and enforce optout check | `identityMapRespectOptOutOption()`, `identityMapNewClientWrongPolicySpecified()`| POST `/v1/identity/map`|
|||`identityMapRespectOptOutOption()`, `identityMapNewClientWrongPolicySpecified()`| POST `/v2/identity/map`|
| Request body doesn't contain optout or policy parameter | Still enforce optout check  | `identityMapNewClientNoPolicySpecified()`| POST `/v1/identity/map`|
|||`identityMapNewClientNoPolicySpecified()`| POST `/v2/identity/map`|

### Manual testing
1] Testing POST 'v1/identity/map' and POST 'v2/identity/map' with policy = 1
```
{
    "email": [
        "test@example.com"
    ],
    "policy": 1
}
```
Response
```
{
    "body": {
        "mapped": [],
        "unmapped": [
            {
                "identifier": "test@example.com",
                "reason": "optout"
            }
        ]
    },
    "status": "success"
}
```
2] Testing POST 'v1/identity/map' and POST 'v2/identity/map' with policy = 0
```
{
    "email": [
        "test@example.com"
    ],
    "policy": 0
}'
```
Response
```
{
    "body": {
        "mapped": [],
        "unmapped": [
            {
                "identifier": "test@example.com",
                "reason": "optout"
            }
        ]
    },
    "status": "success"
}
```

3] Testing POST 'v1/identity/map' and POST 'v2/identity/map' without policy parameter
Request
```
{
    "email": [
        "test@example.com"
    ]
}
```
Response
```
{
    "body": {
        "mapped": [],
        "unmapped": [
            {
                "identifier": "test@example.com",
                "reason": "optout"
            }
        ]
    },
    "status": "success"
}
```