### PR TITLE
Record advertising token version in uid2_token_response_status_count metric

### DIFF
--- a/src/main/java/com/uid2/operator/model/IdentityTokens.java
+++ b/src/main/java/com/uid2/operator/model/IdentityTokens.java
@@ -1,18 +1,22 @@
 package com.uid2.operator.model;
 
+import com.uid2.shared.model.TokenVersion;
+
 import java.time.Instant;
 
 public class IdentityTokens {
-    public static IdentityTokens LogoutToken = new IdentityTokens("", "", Instant.EPOCH, Instant.EPOCH, Instant.EPOCH);
+    public static IdentityTokens LogoutToken = new IdentityTokens("", null, "", Instant.EPOCH, Instant.EPOCH, Instant.EPOCH);
     private final String advertisingToken;
+    private final TokenVersion advertisingTokenVersion;
     private final String refreshToken;
     private final Instant identityExpires;
     private final Instant refreshExpires;
     private final Instant refreshFrom;
 
-    public IdentityTokens(String advertisingToken, String refreshToken,
+    public IdentityTokens(String advertisingToken, TokenVersion advertisingTokenVersion, String refreshToken,
                           Instant identityExpires, Instant refreshExpires, Instant refreshFrom) {
         this.advertisingToken = advertisingToken;
+        this.advertisingTokenVersion = advertisingTokenVersion;
         this.refreshToken = refreshToken;
         this.identityExpires = identityExpires;
         this.refreshExpires = refreshExpires;
@@ -21,6 +25,10 @@ public class IdentityTokens {
 
     public String getAdvertisingToken() {
         return advertisingToken;
+    }
+
+    public TokenVersion getAdvertisingTokenVersion() {
+        return advertisingTokenVersion;
     }
 
     public String getRefreshToken() {

--- a/src/main/java/com/uid2/operator/monitoring/TokenResponseStatsCollector.java
+++ b/src/main/java/com/uid2/operator/monitoring/TokenResponseStatsCollector.java
@@ -2,6 +2,7 @@ package com.uid2.operator.monitoring;
 
 import com.uid2.operator.model.RefreshResponse;
 import com.uid2.operator.vertx.UIDOperatorVerticle;
+import com.uid2.shared.model.TokenVersion;
 import com.uid2.shared.store.ISiteStore;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
@@ -44,11 +45,11 @@ public class TokenResponseStatsCollector {
 
     private static final Map<TokenResponseKey, Counter> TokenResponseCounters = new ConcurrentHashMap<>();
 
-    public static void record(ISiteStore siteStore, Integer siteId, Endpoint endpoint, ResponseStatus responseStatus) {
-        recordInternal(siteStore, siteId, endpoint, responseStatus, endpoint == Endpoint.ClientSideTokenGenerateV2);
+    public static void record(ISiteStore siteStore, Integer siteId, Endpoint endpoint, TokenVersion advertisingTokenVersion, ResponseStatus responseStatus) {
+        recordInternal(siteStore, siteId, endpoint, responseStatus, advertisingTokenVersion, endpoint == Endpoint.ClientSideTokenGenerateV2);
     }
 
-    private static void recordInternal(ISiteStore siteStore, Integer siteId, Endpoint endpoint, ResponseStatus responseStatus, boolean isCstg) {
+    private static void recordInternal(ISiteStore siteStore, Integer siteId, Endpoint endpoint, ResponseStatus responseStatus, TokenVersion advertisingTokenVersion, boolean isCstg) {
         if (siteId == null) return;
 
         TokenResponseCounters.computeIfAbsent(new TokenResponseKey(siteId, endpoint, responseStatus, isCstg), k -> {
@@ -59,6 +60,7 @@ public class TokenResponseStatsCollector {
                             "site_name", UIDOperatorVerticle.getSiteName(siteStore, siteId),
                             "token_endpoint", String.valueOf(endpoint),
                             "token_response_status", String.valueOf(responseStatus),
+                            "advertising_token_version", String.valueOf(advertisingTokenVersion),
                             "cstg", isCstg ? "true" : "false");
 
             return builder.register(Metrics.globalRegistry);
@@ -68,14 +70,14 @@ public class TokenResponseStatsCollector {
     public static void recordRefresh(ISiteStore siteStore, Integer siteId, Endpoint endpoint, RefreshResponse refreshResponse) {
         if (!refreshResponse.isRefreshed()) {
             if (refreshResponse.isOptOut() || refreshResponse.isDeprecated()) {
-                recordInternal(siteStore, siteId, endpoint, ResponseStatus.OptOut, refreshResponse.isCstg());
+                recordInternal(siteStore, siteId, endpoint, ResponseStatus.OptOut, refreshResponse.getTokens().getAdvertisingTokenVersion(), refreshResponse.isCstg());
             } else if (refreshResponse.isInvalidToken()) {
-                recordInternal(siteStore, siteId, endpoint, ResponseStatus.InvalidToken, refreshResponse.isCstg());
+                recordInternal(siteStore, siteId, endpoint, ResponseStatus.InvalidToken, refreshResponse.getTokens().getAdvertisingTokenVersion(), refreshResponse.isCstg());
             } else if (refreshResponse.isExpired()) {
-                recordInternal(siteStore, siteId, endpoint, ResponseStatus.ExpiredToken, refreshResponse.isCstg());
+                recordInternal(siteStore, siteId, endpoint, ResponseStatus.ExpiredToken, refreshResponse.getTokens().getAdvertisingTokenVersion(), refreshResponse.isCstg());
             }
         } else {
-            recordInternal(siteStore, siteId, endpoint, ResponseStatus.Success, refreshResponse.isCstg());
+            recordInternal(siteStore, siteId, endpoint, ResponseStatus.Success, refreshResponse.getTokens().getAdvertisingTokenVersion(), refreshResponse.isCstg());
         }
     }
 

--- a/src/main/java/com/uid2/operator/monitoring/TokenResponseStatsCollector.java
+++ b/src/main/java/com/uid2/operator/monitoring/TokenResponseStatsCollector.java
@@ -7,10 +7,6 @@ import com.uid2.shared.store.ISiteStore;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-
 public class TokenResponseStatsCollector {
     public enum Endpoint {
         GenerateV0,
@@ -43,8 +39,6 @@ public class TokenResponseStatsCollector {
         Unknown
     }
 
-    private static final Map<TokenResponseKey, Counter> TokenResponseCounters = new ConcurrentHashMap<>();
-
     public static void record(ISiteStore siteStore, Integer siteId, Endpoint endpoint, TokenVersion advertisingTokenVersion, ResponseStatus responseStatus) {
         recordInternal(siteStore, siteId, endpoint, responseStatus, advertisingTokenVersion, endpoint == Endpoint.ClientSideTokenGenerateV2);
     }
@@ -52,8 +46,7 @@ public class TokenResponseStatsCollector {
     private static void recordInternal(ISiteStore siteStore, Integer siteId, Endpoint endpoint, ResponseStatus responseStatus, TokenVersion advertisingTokenVersion, boolean isCstg) {
         if (siteId == null) return;
 
-        TokenResponseCounters.computeIfAbsent(new TokenResponseKey(siteId, endpoint, responseStatus, isCstg), k -> {
-            var builder = Counter
+        var builder = Counter
                     .builder("uid2_token_response_status_count")
                     .description("Counter for token response statuses").tags(
                             "site_id", String.valueOf(siteId),
@@ -63,8 +56,7 @@ public class TokenResponseStatsCollector {
                             "advertising_token_version", String.valueOf(advertisingTokenVersion),
                             "cstg", isCstg ? "true" : "false");
 
-            return builder.register(Metrics.globalRegistry);
-        }).increment();
+        builder.register(Metrics.globalRegistry).increment();
     }
 
     public static void recordRefresh(ISiteStore siteStore, Integer siteId, Endpoint endpoint, RefreshResponse refreshResponse) {
@@ -80,32 +72,4 @@ public class TokenResponseStatsCollector {
             recordInternal(siteStore, siteId, endpoint, ResponseStatus.Success, refreshResponse.getTokens().getAdvertisingTokenVersion(), refreshResponse.isCstg());
         }
     }
-
-    static class TokenResponseKey {
-        private final Integer siteId;
-        private final Endpoint endpoint;
-        private final ResponseStatus responseStatus;
-        private final boolean isCstg;
-
-        public TokenResponseKey(Integer siteId, Endpoint endpoint, ResponseStatus responseStatus, boolean isCstg) {
-            this.siteId = siteId;
-            this.endpoint = endpoint;
-            this.responseStatus = responseStatus;
-            this.isCstg = isCstg;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            TokenResponseKey that = (TokenResponseKey) o;
-            return Objects.equals(siteId, that.siteId) && endpoint == that.endpoint && responseStatus == that.responseStatus && Objects.equals(isCstg, that.isCstg);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(siteId, endpoint, responseStatus, isCstg);
-        }
-    }
-
 }

--- a/src/main/java/com/uid2/operator/service/EncryptedTokenEncoder.java
+++ b/src/main/java/com/uid2/operator/service/EncryptedTokenEncoder.java
@@ -324,6 +324,7 @@ public class EncryptedTokenEncoder implements ITokenEncoder {
 
         return new IdentityTokens(
                 base64AdvertisingToken,
+                advertisingToken.version,
                 EncodingUtils.toBase64String(encode(refreshToken, asOf)),
                 advertisingToken.expiresAt,
                 refreshToken.expiresAt,

--- a/src/main/java/com/uid2/operator/service/ResponseUtil.java
+++ b/src/main/java/com/uid2/operator/service/ResponseUtil.java
@@ -2,6 +2,7 @@ package com.uid2.operator.service;
 
 import com.uid2.operator.monitoring.TokenResponseStatsCollector;
 import com.uid2.operator.vertx.UIDOperatorVerticle;
+import com.uid2.shared.model.TokenVersion;
 import com.uid2.shared.store.ISiteStore;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
@@ -65,18 +66,18 @@ public class ResponseUtil {
     public static void SendClientErrorResponseAndRecordStats(String errorStatus, int statusCode, RoutingContext rc, String message, Integer siteId, TokenResponseStatsCollector.Endpoint endpoint, TokenResponseStatsCollector.ResponseStatus responseStatus, ISiteStore siteProvider)
     {
         Warning(errorStatus, statusCode, rc, message);
-        recordTokenResponseStats(siteId, endpoint, responseStatus, siteProvider);
+        recordTokenResponseStats(siteId, endpoint, responseStatus, siteProvider, null);
     }
 
     public static void SendServerErrorResponseAndRecordStats(RoutingContext rc, String message, Integer siteId, TokenResponseStatsCollector.Endpoint endpoint, TokenResponseStatsCollector.ResponseStatus responseStatus, ISiteStore siteProvider, Exception exception)
     {
         Error(ResponseStatus.UnknownError, 500, rc, message, exception);
         rc.fail(500);
-        recordTokenResponseStats(siteId, endpoint, responseStatus, siteProvider);
+        recordTokenResponseStats(siteId, endpoint, responseStatus, siteProvider, null);
     }
 
-    public static void recordTokenResponseStats(Integer siteId, TokenResponseStatsCollector.Endpoint endpoint, TokenResponseStatsCollector.ResponseStatus responseStatus, ISiteStore siteProvider) {
-        TokenResponseStatsCollector.record(siteProvider, siteId, endpoint, responseStatus);
+    public static void recordTokenResponseStats(Integer siteId, TokenResponseStatsCollector.Endpoint endpoint, TokenResponseStatsCollector.ResponseStatus responseStatus, ISiteStore siteProvider, TokenVersion advertisingTokenVersion) {
+        TokenResponseStatsCollector.record(siteProvider, siteId, endpoint, advertisingTokenVersion, responseStatus);
     }
 
     public static JsonObject Response(String status, String message) {

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -430,7 +430,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
 
         final byte[] encryptedResponse = AesGcm.encrypt(response.toBuffer().getBytes(), sharedSecret);
         rc.response().setStatusCode(200).end(Buffer.buffer(Unpooled.wrappedBuffer(Base64.getEncoder().encode(encryptedResponse))));
-        recordTokenResponseStats(clientSideKeypair.getSiteId(), TokenResponseStatsCollector.Endpoint.ClientSideTokenGenerateV2, TokenResponseStatsCollector.ResponseStatus.Success, siteProvider);
+        recordTokenResponseStats(clientSideKeypair.getSiteId(), TokenResponseStatsCollector.Endpoint.ClientSideTokenGenerateV2, TokenResponseStatsCollector.ResponseStatus.Success, siteProvider, identityTokens.getAdvertisingTokenVersion());
     }
 
     private byte[] decrypt(byte[] encryptedBytes, int offset, byte[] secretBytes, byte[] aad) throws InvalidAlgorithmParameterException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
@@ -749,7 +749,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                 //Integer.parseInt(rc.queryParam("privacy_bits").get(0))));
 
                 ResponseUtil.Success(rc, toJsonV1(t));
-                recordTokenResponseStats(siteId, TokenResponseStatsCollector.Endpoint.GenerateV1, TokenResponseStatsCollector.ResponseStatus.Success, siteProvider);
+                recordTokenResponseStats(siteId, TokenResponseStatsCollector.Endpoint.GenerateV1, TokenResponseStatsCollector.ResponseStatus.Success, siteProvider, t.getAdvertisingTokenVersion());
             }
         } catch (Exception e) {
             SendServerErrorResponseAndRecordStats(rc, "Unknown error while generating token v1", siteId, TokenResponseStatsCollector.Endpoint.GenerateV1, TokenResponseStatsCollector.ResponseStatus.Unknown, siteProvider, e);
@@ -774,7 +774,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                     }
                     case INSUFFICIENT: {
                         ResponseUtil.SuccessNoBodyV2(ResponseStatus.InsufficientUserConsent, rc);
-                        recordTokenResponseStats(siteId, TokenResponseStatsCollector.Endpoint.GenerateV2, TokenResponseStatsCollector.ResponseStatus.InsufficientUserConsent, siteProvider);
+                        recordTokenResponseStats(siteId, TokenResponseStatsCollector.Endpoint.GenerateV2, TokenResponseStatsCollector.ResponseStatus.InsufficientUserConsent, siteProvider, null);
                         return;
                     }
                     case SUFFICIENT: {
@@ -802,10 +802,10 @@ public class UIDOperatorVerticle extends AbstractVerticle {
 
                 if (t.isEmptyToken()) {
                     ResponseUtil.SuccessNoBodyV2("optout", rc);
-                    recordTokenResponseStats(siteId, TokenResponseStatsCollector.Endpoint.GenerateV2, TokenResponseStatsCollector.ResponseStatus.OptOut, siteProvider);
+                    recordTokenResponseStats(siteId, TokenResponseStatsCollector.Endpoint.GenerateV2, TokenResponseStatsCollector.ResponseStatus.OptOut, siteProvider, null);
                 } else {
                     ResponseUtil.SuccessV2(rc, toJsonV1(t));
-                    recordTokenResponseStats(siteId, TokenResponseStatsCollector.Endpoint.GenerateV2, TokenResponseStatsCollector.ResponseStatus.Success, siteProvider);
+                    recordTokenResponseStats(siteId, TokenResponseStatsCollector.Endpoint.GenerateV2, TokenResponseStatsCollector.ResponseStatus.Success, siteProvider, t.getAdvertisingTokenVersion());
                 }
             }
         } catch (ClientInputValidationException cie) {
@@ -837,7 +837,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
 
             //Integer.parseInt(rc.queryParam("privacy_bits").get(0))));
 
-            recordTokenResponseStats(siteId, TokenResponseStatsCollector.Endpoint.GenerateV0, TokenResponseStatsCollector.ResponseStatus.Success, siteProvider);
+            recordTokenResponseStats(siteId, TokenResponseStatsCollector.Endpoint.GenerateV0, TokenResponseStatsCollector.ResponseStatus.Success, siteProvider, t.getAdvertisingTokenVersion());
             sendJsonResponse(rc, toJson(t));
 
         } catch (Exception e) {

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -532,12 +532,14 @@ public class UIDOperatorVerticleTest {
     }
 
     private void assertTokenStatusMetrics(Integer siteId, TokenResponseStatsCollector.Endpoint endpoint, TokenResponseStatsCollector.ResponseStatus responseStatus) {
-        assertEquals(1, Metrics.globalRegistry
+        final double actual = Metrics.globalRegistry
                 .get("uid2_token_response_status_count")
                 .tag("site_id", String.valueOf(siteId))
                 .tag("token_endpoint", String.valueOf(endpoint))
                 .tag("token_response_status", String.valueOf(responseStatus))
-                .counter().count());
+                .tag("advertising_token_version", responseStatus == TokenResponseStatsCollector.ResponseStatus.Success ? String.valueOf(getTokenVersion()) : "null")
+                .counter().count();
+        assertEquals(1, actual);
     }
 
     private byte[] getAdvertisingIdFromIdentity(IdentityType identityType, String identityString, String firstLevelSalt, String rotatingSalt) {


### PR DESCRIPTION
This pull request adds the `advertising_token_version` label to the `uid2_token_response_status_count` metric.

It also removes the second layer of caching of the counter - Micrometer already does this for us. Having to update the `TokenResponseKey` class every time we add a label complicates things.