### PR TITLE
Build all Operators pipeline

### DIFF
--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -10,8 +10,7 @@ on:
         - Major
         - Minor
         - Patch
-        - Snapshot  #remove this
-  
+
 jobs:
   start:
     name: Start Operator Build
@@ -72,6 +71,22 @@ jobs:
   #  name: AWS Private Operator
   #  needs: start
   #  uses: ./.github/workflows/publish-aws-operator-AMI.yaml
+  #  with:
+  #    release_type: ${{ inputs.release_type }}
+  #    version_number_input: ${{ needs.start.outputs.new_version }}
+
+  #buildGCP:
+  #  name: GCP Private Operator
+  #  needs: start
+  #  uses: ./.github/workflows/publish-gcp-operator-docker-image.yaml
+  #  with:
+  #    release_type: ${{ inputs.release_type }}
+  #    version_number_input: ${{ needs.start.outputs.new_version }}
+
+  #buildAzure:
+  #  name: Azure Private Operator
+  #  needs: start
+  #  uses: ./.github/workflows/publish-azure-operator-docker-image.yaml
   #  with:
   #    release_type: ${{ inputs.release_type }}
   #    version_number_input: ${{ needs.start.outputs.new_version }}

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -1,7 +1,6 @@
 name: Publish All Operators
 run-name: ${{ format('Publish All {0} Operators', inputs.release_type) }}
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       release_type:
@@ -27,10 +26,10 @@ jobs:
         env: 
             GITHUB_CONTEXT: ${{ toJson(github) }}
 
-      - name: Check branch and release type
-        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2.2
-        with:
-          release_type: ${{ inputs.release_type }}
+      #- name: Check branch and release type
+      #  uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2.2
+      #  with:
+      #    release_type: ${{ inputs.release_type }}
     
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -10,13 +10,14 @@ on:
         - Major
         - Minor
         - Patch
+        - Snapshot  #remove this
   
 jobs:
   start:
     name: Start Operator Build
     runs-on: ubuntu-latest
-    #outputs:
-    #    new_version: ${{ steps.version.outputs.new_version }}
+    outputs:
+        new_version: ${{ steps.version.outputs.new_version }}
     steps:
       - name: Show Context
         run: |
@@ -26,38 +27,38 @@ jobs:
         env: 
             GITHUB_CONTEXT: ${{ toJson(github) }}
 
-      #- name: Check branch and release type
-      #  uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2.2
-      #  with:
-      #    release_type: ${{ inputs.release_type }}
+      - name: Check branch and release type
+        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2.2
+        with:
+          release_type: ${{ inputs.release_type }}
     
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      #- name: Set version number
-      #  id: version
-      #  uses: IABTechLab/uid2-shared-actions/actions/version_number@v1.0
-      #  with:
-      #    type: ${{ inputs.release_type }}
-      #    branch_name: ${{ github.ref }}
-#
-      #- name: Update pom.xml
-      #  run: |
-      #    current_version=$(grep -o '<version>.*</version>' pom.xml | head -1 | sed 's/<version>\(.*\)<\/version>/\1/')
-      #    new_version=${{ steps.version.outputs.new_version }} 
-      #    sed -i "s/$current_version/$new_version/g" pom.xml
-      #    echo "Version number updated from $current_version to $new_version"
-#
-      #- name: Commit pom.xml and version.json
-      #  uses: EndBug/add-and-commit@v9
-      #  with:
-      #    add: 'pom.xml version.json'
-      #    author_name: Release Workflow
-      #    author_email: unifiedid-admin+release@thetradedesk.com
-      #    message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
-      #    tag: v${{ steps.version.outputs.new_version }}
+      - name: Set version number
+        id: version
+        uses: IABTechLab/uid2-shared-actions/actions/version_number@v1.0
+        with:
+          type: ${{ inputs.release_type }}
+          branch_name: ${{ github.ref }}
+
+      - name: Update pom.xml
+        run: |
+          current_version=$(grep -o '<version>.*</version>' pom.xml | head -1 | sed 's/<version>\(.*\)<\/version>/\1/')
+          new_version=${{ steps.version.outputs.new_version }} 
+          sed -i "s/$current_version/$new_version/g" pom.xml
+          echo "Version number updated from $current_version to $new_version"
+
+      - name: Commit pom.xml and version.json
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: 'pom.xml version.json'
+          author_name: Release Workflow
+          author_email: unifiedid-admin+release@thetradedesk.com
+          message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
+          tag: v${{ steps.version.outputs.new_version }}
   
   buildPublic:
     name: Public Operator
@@ -65,7 +66,7 @@ jobs:
     uses: ./.github/workflows/publish-public-operator-docker-image.yaml
     with:
       release_type: ${{ inputs.release_type }}
-      version_number_input: '2.3.5-abcd1234'
+      version_number_input: ${{ needs.start.outputs.new_version }}
 
   #buildAWS:
   #  name: AWS Private Operator
@@ -87,3 +88,13 @@ jobs:
         shell: bash
         env: 
             GITHUB_CONTEXT: ${{ toJson(github) }}
+
+      - name: Download Public Artifacts
+        uses: Legit-Labs/action-download-artifact@v2
+        with:
+          worflow: publish-public-operator-docker-image.yaml
+          workflow_conclusion: success
+          branch: main
+          run_id: ${{ github.run_id }}
+          path: public_operator
+

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -10,6 +10,7 @@ on:
         - Major
         - Minor
         - Patch
+        - Snapshot
 
 jobs:
   start:

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -96,14 +96,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [buildPublic]
     steps:
-      - name: Show Context
-        run: |
-          printenv
-          echo "$GITHUB_CONTEXT"
-        shell: bash
-        env: 
-            GITHUB_CONTEXT: ${{ toJson(github) }}
-
       - name: Download Public Artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -90,11 +90,11 @@ jobs:
             GITHUB_CONTEXT: ${{ toJson(github) }}
 
       - name: Download Public Artifacts
-        uses: Legit-Labs/action-download-artifact@v2
+        uses: Legit-Labs/action-download-artifact@v2.18.0
         with:
-          worflow: publish-public-operator-docker-image.yaml
+          workflow: publish-public-operator-docker-image.yaml
           workflow_conclusion: success
           branch: main
           run_id: ${{ github.run_id }}
-          path: public_operator
+          path: ./artifacts/public_operator
 

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -1,5 +1,5 @@
 name: Publish All Operators
-run-name: ${{ format('Publish All {0} Operators', inputs.release_type) }}
+run-name: ${{ format('Publish All Operators: {0} Release', inputs.release_type) }}
 on:
   workflow_dispatch:
     inputs:
@@ -90,11 +90,14 @@ jobs:
             GITHUB_CONTEXT: ${{ toJson(github) }}
 
       - name: Download Public Artifacts
-        uses: Legit-Labs/action-download-artifact@v2.18.0
+        uses: actions/download-artifact@v3
         with:
-          workflow: publish-public-operator-docker-image.yaml
-          workflow_conclusion: success
-          branch: main
-          run_id: ${{ github.run_id }}
+          name: image_details
           path: ./artifacts/public_operator
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: operator_release
+          path: ./artifacts/
+  

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -1,0 +1,90 @@
+name: Publish All Operators
+run-name: ${{ format('Publish All {0} Operators', inputs.release_type) }}
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        type: choice
+        description: 'The type of release'
+        options:
+        - Major
+        - Minor
+        - Patch
+  
+jobs:
+  start:
+    name: Start Operator Build
+    runs-on: ubuntu-latest
+    #outputs:
+    #    new_version: ${{ steps.version.outputs.new_version }}
+    steps:
+      - name: Show Context
+        run: |
+          printenv
+          echo "$GITHUB_CONTEXT"
+        shell: bash
+        env: 
+            GITHUB_CONTEXT: ${{ toJson(github) }}
+
+      - name: Check branch and release type
+        uses: IABTechLab/uid2-shared-actions/actions/check_branch_and_release_type@v2.2
+        with:
+          release_type: ${{ inputs.release_type }}
+    
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      #- name: Set version number
+      #  id: version
+      #  uses: IABTechLab/uid2-shared-actions/actions/version_number@v1.0
+      #  with:
+      #    type: ${{ inputs.release_type }}
+      #    branch_name: ${{ github.ref }}
+#
+      #- name: Update pom.xml
+      #  run: |
+      #    current_version=$(grep -o '<version>.*</version>' pom.xml | head -1 | sed 's/<version>\(.*\)<\/version>/\1/')
+      #    new_version=${{ steps.version.outputs.new_version }} 
+      #    sed -i "s/$current_version/$new_version/g" pom.xml
+      #    echo "Version number updated from $current_version to $new_version"
+#
+      #- name: Commit pom.xml and version.json
+      #  uses: EndBug/add-and-commit@v9
+      #  with:
+      #    add: 'pom.xml version.json'
+      #    author_name: Release Workflow
+      #    author_email: unifiedid-admin+release@thetradedesk.com
+      #    message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
+      #    tag: v${{ steps.version.outputs.new_version }}
+  
+  buildPublic:
+    name: Public Operator
+    needs: start
+    uses: ./.github/workflows/publish-public-operator-docker-image.yaml
+    with:
+      release_type: ${{ inputs.release_type }}
+      version_number_input: '2.3.5-abcd1234'
+
+  #buildAWS:
+  #  name: AWS Private Operator
+  #  needs: start
+  #  uses: ./.github/workflows/publish-aws-operator-AMI.yaml
+  #  with:
+  #    release_type: ${{ inputs.release_type }}
+  #    version_number_input: ${{ needs.start.outputs.new_version }}
+
+  collectAllArtifacts:
+    name: Collect All Artifacts
+    runs-on: ubuntu-latest
+    needs: [buildPublic]
+    steps:
+      - name: Show Context
+        run: |
+          printenv
+          echo "$GITHUB_CONTEXT"
+        shell: bash
+        env: 
+            GITHUB_CONTEXT: ${{ toJson(github) }}

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -10,7 +10,6 @@ on:
         - Major
         - Minor
         - Patch
-        - Snapshot
 
 jobs:
   start:

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -1,5 +1,5 @@
 name: Publish All Operators
-run-name: ${{ format('Publish All Operators: {0} Release', inputs.release_type) }}
+run-name: ${{ format('Publish All Operators{0} {1} Release', ':', inputs.release_type) }}
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish-public-operator-docker-image.yaml
+++ b/.github/workflows/publish-public-operator-docker-image.yaml
@@ -25,6 +25,7 @@ on:
         description: If set, the version number will not be incremented and the given number will be used.
         type: string
         default: ''
+      
     outputs:
       image_tag:
         description: The tag used to describe the image in docker
@@ -32,7 +33,7 @@ on:
   
 jobs:
   Image:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-docker-versioned.yaml@v2.2
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-docker-versioned.yaml@v2.2.1-pre
     with: 
       release_type: ${{ inputs.release_type }}
       version_number_input: ${{ inputs.version_number_input }}

--- a/.github/workflows/publish-public-operator-docker-image.yaml
+++ b/.github/workflows/publish-public-operator-docker-image.yaml
@@ -21,6 +21,10 @@ on:
         description: The type of version number to return. Must be one of [Snapshot, Patch, Minor or Major]
         required: true
         type: string
+      version_number_input:
+        description: If set, the version number will not be incremented and the given number will be used.
+        type: string
+        default: ''
     outputs:
       image_tag:
         description: The tag used to describe the image in docker

--- a/.github/workflows/publish-public-operator-docker-image.yaml
+++ b/.github/workflows/publish-public-operator-docker-image.yaml
@@ -33,7 +33,7 @@ on:
   
 jobs:
   Image:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-docker-versioned.yaml@v2.2.1-pre
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-docker-versioned.yaml@v2.2.1
     with: 
       release_type: ${{ inputs.release_type }}
       version_number_input: ${{ inputs.version_number_input }}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.22.30-SNAPSHOT</version>
+    <version>5.22.10-1cfb02c95e</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.22.10-1cfb02c95e</version>
+    <version>5.22.35-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.22.35-SNAPSHOT</version>
+    <version>5.22.36-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.22.27-SNAPSHOT</version>
+    <version>5.22.30-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.22.36-SNAPSHOT</version>
+    <version>5.22.10-1cfb02c95e</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Parent pipeline that creates the version number, calls each of the operator pipelines and builds them.
It then collects the artifacts.
Tested on a branch with only calling the public operator build as that is what is currently ready.
Will need to be tested once merged to main.