### PR TITLE
UID2-2343 Add trivy scanning 

### DIFF
--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
 
       - name: Vulnerability Scan
-        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan_filesystem@v2.4.0-pre
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan_filesystem@v2.4.0
         with:
           scan_severity: HIGH,CRITICAL
           failure_severity: CRITICAL

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -10,6 +10,7 @@ on:
         - Major
         - Minor
         - Patch
+        - Snapshot
 
 jobs:
   start:

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -40,7 +40,8 @@ jobs:
       - name: Vulnerability Scan
         uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan_filesystem@v2.4.0-pre
         with:
-          publish_vulnerabilities: true
+          scan_severity: MEDIUM,HIGH,CRITICAL
+          failure_severity: HIGH,CRITICAL
 
       - name: Set version number
         id: version

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -40,8 +40,8 @@ jobs:
       - name: Vulnerability Scan
         uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan_filesystem@v2.4.0-pre
         with:
-          scan_severity: MEDIUM,HIGH,CRITICAL
-          failure_severity: HIGH,CRITICAL
+          scan_severity: HIGH,CRITICAL
+          failure_severity: CRITICAL
 
       - name: Set version number
         id: version

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -10,7 +10,6 @@ on:
         - Major
         - Minor
         - Patch
-        - Snapshot
 
 jobs:
   start:

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -36,6 +36,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Vulnerability Scan
+        uses: IABTechLab/uid2-shared-actions/actions/vulnerability_scan_filesystem@v2.4.0-pre
+        with:
+          publish_vulnerabilities: true
+
       - name: Set version number
         id: version
         uses: IABTechLab/uid2-shared-actions/actions/version_number@v1.0

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.24.13-SNAPSHOT</version>
+    <version>5.24.4-c19825cb6f</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.24.4-c19825cb6f</version>
+    <version>5.24.9-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Adding scanning early to detect errors early in the pipeline. Scanning will be done again on the images. This is only scanning the code.
Tested on a branch.
Will need to be tested once merge.