### PR TITLE
Removed the ability to set the urls from the environment

### DIFF
--- a/scripts/azure-cc/entrypoint.sh
+++ b/scripts/azure-cc/entrypoint.sh
@@ -53,18 +53,18 @@ fi
 
 # -- replace base URLs if both CORE_BASE_URL and OPTOUT_BASE_URL are provided
 # -- using hardcoded domains is fine because they should not be changed frequently
-if [ -n "${CORE_BASE_URL}" -a -n "${OPTOUT_BASE_URL}" -a "${DEPLOYMENT_ENVIRONMENT}" != 'prod' ]; then
-    echo "-- replacing URLs by ${CORE_BASE_URL} and ${OPTOUT_BASE_URL}"
-    sed -i "s#https://core-integ.uidapi.com#${CORE_BASE_URL}#g" ${FINAL_CONFIG}
-
-    sed -i "s#https://optout-integ.uidapi.com#${OPTOUT_BASE_URL}#g" ${FINAL_CONFIG}
-fi
+#if [ -n "${CORE_BASE_URL}" -a -n "${OPTOUT_BASE_URL}" -a "${DEPLOYMENT_ENVIRONMENT}" != 'prod' ]; then
+#    echo "-- replacing URLs by ${CORE_BASE_URL} and ${OPTOUT_BASE_URL}"
+#    sed -i "s#https://core-integ.uidapi.com#${CORE_BASE_URL}#g" ${FINAL_CONFIG}
+#
+#    sed -i "s#https://optout-integ.uidapi.com#${OPTOUT_BASE_URL}#g" ${FINAL_CONFIG}
+#fi
 
 # -- replace `enforce_https` value to ENFORCE_HTTPS if provided
-if [ "${ENFORCE_HTTPS}" == false ]; then
-    echo "-- replacing enforce_https by ${ENFORCE_HTTPS}"
-    jq_inplace_update_json $FINAL_CONFIG enforce_https false
-fi
+#if [ "${ENFORCE_HTTPS}" == false ]; then
+#    echo "-- replacing enforce_https by ${ENFORCE_HTTPS}"
+#    jq_inplace_update_json $FINAL_CONFIG enforce_https false
+#fi
 
 cat $FINAL_CONFIG
 

--- a/scripts/gcp-oidc/entrypoint.sh
+++ b/scripts/gcp-oidc/entrypoint.sh
@@ -47,18 +47,18 @@ fi
 
 # -- replace base URLs if both CORE_BASE_URL and OPTOUT_BASE_URL are provided
 # -- using hardcoded domains is fine because they should not be changed frequently
-if [ -n "${CORE_BASE_URL}" -a -n "${OPTOUT_BASE_URL}" -a "${DEPLOYMENT_ENVIRONMENT}" != 'prod' ]; then
-    echo "-- replacing URLs by ${CORE_BASE_URL} and ${OPTOUT_BASE_URL}"
-    sed -i "s#https://core-integ.uidapi.com#${CORE_BASE_URL}#g" ${FINAL_CONFIG}
+#if [ -n "${CORE_BASE_URL}" -a -n "${OPTOUT_BASE_URL}" -a "${DEPLOYMENT_ENVIRONMENT}" != 'prod' ]; then
+#    echo "-- replacing URLs by ${CORE_BASE_URL} and ${OPTOUT_BASE_URL}"
+#    sed -i "s#https://core-integ.uidapi.com#${CORE_BASE_URL}#g" ${FINAL_CONFIG}
 
-    sed -i "s#https://optout-integ.uidapi.com#${OPTOUT_BASE_URL}#g" ${FINAL_CONFIG}
-fi
+#    sed -i "s#https://optout-integ.uidapi.com#${OPTOUT_BASE_URL}#g" ${FINAL_CONFIG}
+#fi
 
 # -- replace `enforce_https` value to ENFORCE_HTTPS if provided
-if [ "${ENFORCE_HTTPS}" == false ]; then
-    echo "-- replacing enforce_https by ${ENFORCE_HTTPS}"
-    jq_inplace_update_json $FINAL_CONFIG enforce_https false
-fi
+#if [ "${ENFORCE_HTTPS}" == false ]; then
+#    echo "-- replacing enforce_https by ${ENFORCE_HTTPS}"
+#    jq_inplace_update_json $FINAL_CONFIG enforce_https false
+#fi
 
 cat $FINAL_CONFIG
 


### PR DESCRIPTION
This will break the e2e testing, but is required to keep the operators secure. Another approach will be needed to enable end to end testing