### PR TITLE
UID2-2861 Fix-github-warnings

### DIFF
--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -96,19 +96,19 @@ jobs:
     needs: [start, buildPublic, buildGCP, buildAzure]
     steps:
       - name: Download public artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: image-details
           path: ./artifacts/public_operator
 
       - name: Download GCP artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gcp-oidc-deployment-files
           path: ./artifacts/gcp_oidc_operator
 
       - name: Download Azure artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: azure-cc-deployment-files
           path: ./artifacts/azure_cc_operator

--- a/.github/workflows/run-e2e-tests-on-operator.yaml
+++ b/.github/workflows/run-e2e-tests-on-operator.yaml
@@ -84,7 +84,7 @@ on:
 jobs:
   e2e-test:
     name: E2E Test
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-run-e2e-tests.yaml@kcc-UID2-2861-fix-github-warnings
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-run-e2e-tests.yaml@v2
     with:
       operator_type: ${{ inputs.operator_type }}
       operator_image_version: ${{ inputs.operator_image_version }}

--- a/.github/workflows/run-e2e-tests-on-operator.yaml
+++ b/.github/workflows/run-e2e-tests-on-operator.yaml
@@ -84,7 +84,7 @@ on:
 jobs:
   e2e-test:
     name: E2E Test
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-run-e2e-tests.yaml@v2
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-run-e2e-tests.yaml@kcc-UID2-2861-fix-github-warnings
     with:
       operator_type: ${{ inputs.operator_type }}
       operator_image_version: ${{ inputs.operator_image_version }}


### PR DESCRIPTION
* https://github.com/thetradedesk/git-restore-mtime-action/pull/2, this is to update node version for thetradedesk/git-restore-mtime-action@v1.2, also pulled in the latest change from chetan/git-restore-mtime-action@v2

Once the above is merged and released, I will make the related update in below to get rid of all the warnings (except for azure/login@v1):

- https://github.com/IABTechLab/uid2-operator/pull/362
- https://github.com/IABTechLab/uid2-shared-actions/pull/70