### PR TITLE
Save eif for uid2 and euid

### DIFF
--- a/.github/workflows/publish-aws-nitro-enclave-docker.yaml
+++ b/.github/workflows/publish-aws-nitro-enclave-docker.yaml
@@ -122,9 +122,10 @@ jobs:
           artifacts_base_output_dir: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/uid2
 
       - name: Archive deployment artifacts
+        if: ${{ inputs.version_number_input != '' || steps.checkRelease.outputs.is_release != 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: uid2-nitro-deployment-files
+          name: uid2-nitro-deployment-files-${{ steps.version.outputs.new_version }}
           path: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/uid2
           if-no-files-found: error
   
@@ -135,16 +136,18 @@ jobs:
           artifacts_base_output_dir: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/euid
 
       - name: Archive deployment artifacts
+        if: ${{ inputs.version_number_input != '' || steps.checkRelease.outputs.is_release != 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: euid-nitro-deployment-files
+          name: euid-nitro-deployment-files-${{ steps.version.outputs.new_version }}
           path: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/euid
           if-no-files-found: error
 
-      - name: Generate release archive
+      - name: Generate release archive files
         if: ${{ inputs.version_number_input == '' && steps.checkRelease.outputs.is_release == 'true' }}
         run: |
-          zip -j ${{ env.ARTIFACTS_OUTPUT_DIR }}/uid2-operator-deployment-artifacts-${{ steps.meta.outputs.version }}.zip ${{ env.ARTIFACTS_OUTPUT_DIR }}/*
+          zip -j ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/uid2-nitro-deployment-artifacts-${{ steps.version.outputs.new_version }}.zip ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/uid2/*
+          zip -j ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/euid-nitro-deployment-artifacts-${{ steps.version.outputs.new_version }}.zip ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/euid/*
 
       - name: Build changelog
         id: github_release
@@ -153,7 +156,7 @@ jobs:
         with:
           configurationJson: |
             {
-              "template": "#{{CHANGELOG}}\n## Installation\n```\ndocker pull ${{ steps.meta.outputs.tags }}\n```\n\n## Image reference to deploy: \n```\n${{ steps.updatePom.outputs.image_tag }}\n```\n\n## Changelog\n#{{UNCATEGORIZED}}",
+              "template": "#{{CHANGELOG}}\n## Installation\n```\ndocker pull ${{ steps.version.outputs.tags }}\n```\n\n## Image reference to deploy: \n```\n${{ steps.updatePom.outputs.image_tag }}\n```\n\n## Changelog\n#{{UNCATEGORIZED}}",
               "pr_template": " - #{{TITLE}} - ( PR: ##{{NUMBER}} )"
             }
         env:
@@ -167,4 +170,6 @@ jobs:
           body: ${{ steps.github_release.outputs.changelog }}
           draft: true
           files: |
-            ${{ env.ARTIFACTS_OUTPUT_DIR }}/uid2-operator-deployment-artifacts-${{ steps.meta.outputs.version }}.zip
+            ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/uid2-nitro-deployment-artifacts-${{ steps.version.outputs.new_version }}.zip
+            ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/euid-nitro-deployment-artifacts-${{ steps.version.outputs.new_version }}.zip
+

--- a/.github/workflows/publish-aws-nitro-enclave-docker.yaml
+++ b/.github/workflows/publish-aws-nitro-enclave-docker.yaml
@@ -119,19 +119,26 @@ jobs:
         uses: IABTechLab/uid2-operator/.github/actions/build_aws_eif@main
         with:
           identity_scope: uid2
-          artifacts_base_output_dir: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}
-
-      - name: Build EUID AWS EIF
-        uses: IABTechLab/uid2-operator/.github/actions/build_aws_eif@main
-        with:
-          identity_scope: euid
-          artifacts_base_output_dir: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}
+          artifacts_base_output_dir: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/uid2
 
       - name: Archive deployment artifacts
         uses: actions/upload-artifact@v4
         with:
           name: aws-nitro-deployment-files
-          path: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}
+          path: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/uid2
+          if-no-files-found: error
+  
+      - name: Build EUID AWS EIF
+        uses: IABTechLab/uid2-operator/.github/actions/build_aws_eif@main
+        with:
+          identity_scope: euid
+          artifacts_base_output_dir: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/euid
+
+      - name: Archive deployment artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: aws-nitro-deployment-files
+          path: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/euid
           if-no-files-found: error
 
       - name: Generate release archive

--- a/.github/workflows/publish-aws-nitro-enclave-docker.yaml
+++ b/.github/workflows/publish-aws-nitro-enclave-docker.yaml
@@ -124,7 +124,7 @@ jobs:
       - name: Archive deployment artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: aws-nitro-deployment-files
+          name: uid2-nitro-deployment-files
           path: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/uid2
           if-no-files-found: error
   
@@ -137,7 +137,7 @@ jobs:
       - name: Archive deployment artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: aws-nitro-deployment-files
+          name: euid-nitro-deployment-files
           path: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/euid
           if-no-files-found: error
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.28.19-SNAPSHOT</version>
+    <version>5.28.14-3e9aa4187a</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.28.17-SNAPSHOT</version>
+    <version>5.28.19-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Saving the EIF files as separate artifacts means that only the required files are downloaded when building the AMI.

Test run:
https://github.com/IABTechLab/uid2-operator/actions/runs/8319307678

This will need to be tested as part of a full release