### PR TITLE
UID2-2071 Enable log redirect

### DIFF
--- a/scripts/gcp-oidc/Dockerfile
+++ b/scripts/gcp-oidc/Dockerfile
@@ -2,6 +2,7 @@
 FROM eclipse-temurin@sha256:564eb67091b2cda82952299b4be52bf1b039289234b52f46057fe1286c173b71
 
 LABEL "tee.launch_policy.allow_env_override"="API_TOKEN_SECRET_NAME,DEPLOYMENT_ENVIRONMENT,CORE_BASE_URL,OPTOUT_BASE_URL"
+LABEL "tee.launch_policy.log_redirect"="always"
 
 # Install Packages
 RUN apk update && apk add jq

--- a/scripts/gcp-oidc/README.md
+++ b/scripts/gcp-oidc/README.md
@@ -185,7 +185,7 @@ $ gcloud compute instances create {INSTANCE_NAME} \
   --image-project confidential-space-images \
   --image-family confidential-space \
   --service-account {SERVICE_ACCOUNT} \
-  --metadata ^~^tee-image-reference={OPERATOR_IMAGE}~tee-restart-policy=Never~tee-env-DEPLOYMENT_ENVIRONMENT=integ~tee-env-API_TOKEN_SECRET_NAME={OPERATOR_KEY_SECRET_FULL_NAME}
+  --metadata ^~^tee-image-reference={OPERATOR_IMAGE}~tee-restart-policy=Never~tee-container-log-redirect=true~tee-env-DEPLOYMENT_ENVIRONMENT=integ~tee-env-API_TOKEN_SECRET_NAME={OPERATOR_KEY_SECRET_FULL_NAME}
 ```
 
 ## Production Deployment
@@ -212,7 +212,7 @@ $ gcloud compute instances create {INSTANCE_NAME} \
   --image-project confidential-space-images \
   --image-family confidential-space \
   --service-account {SERVICE_ACCOUNT} \
-  --metadata ^~^tee-image-reference={OPERATOR_IMAGE}~tee-restart-policy=Never~tee-env-DEPLOYMENT_ENVIRONMENT=prod~tee-env-API_TOKEN_SECRET_NAME={OPERATOR_KEY_SECRET_FULL_NAME}
+  --metadata ^~^tee-image-reference={OPERATOR_IMAGE}~tee-restart-policy=Never~tee-container-log-redirect=true~tee-env-DEPLOYMENT_ENVIRONMENT=prod~tee-env-API_TOKEN_SECRET_NAME={OPERATOR_KEY_SECRET_FULL_NAME}
 ```
 
 Note that compared to the `gcloud` command used in the prior section, parameter `--machine-type n2d-standard-16` is set to ensure production deployment of UID2 Operator runs on the recommended machine type for production.

--- a/scripts/gcp-oidc/terraform/main.tf
+++ b/scripts/gcp-oidc/terraform/main.tf
@@ -104,7 +104,7 @@ resource "google_compute_instance_template" "uid_operator" {
 
   metadata = {
     tee-image-reference            = var.uid_operator_image
-    tee-container-log-redirect     = var.debug_mode
+    tee-container-log-redirect     = true
     tee-restart-policy             = "Never"
     tee-env-DEPLOYMENT_ENVIRONMENT = var.uid_deployment_env
     tee-env-API_TOKEN_SECRET_NAME  = module.secret-manager.secret_versions[0]


### PR DESCRIPTION
Tested it working with "confidential-space" family: (https://console.cloud.google.com/logs/query;query=resource.type%3D%22gce_instance%22%0Aresource.labels.instance_id%3D%224236641475715379579%22;cursorTimestamp=2024-04-16T05:43:59.110328Z;duration=PT1H?orgonly=true&project=uid2-developer-project&supportedpurview=organizationId)


![image](https://github.com/IABTechLab/uid2-operator/assets/11983300/01c17749-8e5e-4580-a01c-f81fe04543d7)

