### PR TITLE
[UID2-2831] Send Site's app name in key/sharing  and key/bidstream endpoints

### DIFF
--- a/conf/local-config.json
+++ b/conf/local-config.json
@@ -34,7 +34,6 @@
   "optout_partition_interval": 86400,
   "client_side_token_generate": true,
   "client_side_token_generate_domain_name_check_enabled": true,
-  "key_sharing_endpoint_provide_site_domain_names": true,
   "key_sharing_endpoint_provide_app_names": true,
   "client_side_token_generate_log_invalid_http_origins": true,
   "salts_expired_shutdown_hours": 12

--- a/conf/local-config.json
+++ b/conf/local-config.json
@@ -35,6 +35,7 @@
   "client_side_token_generate": true,
   "client_side_token_generate_domain_name_check_enabled": true,
   "key_sharing_endpoint_provide_site_domain_names": true,
+  "key_sharing_endpoint_provide_app_names": true,
   "client_side_token_generate_log_invalid_http_origins": true,
   "salts_expired_shutdown_hours": 12
 }

--- a/conf/local-e2e-docker-public-config.json
+++ b/conf/local-e2e-docker-public-config.json
@@ -24,7 +24,6 @@
   "client_side_token_generate": true,
   "client_side_token_generate_domain_name_check_enabled": true,
   "client_side_token_generate_log_invalid_http_origins": true,
-  "key_sharing_endpoint_provide_site_domain_names": true,
   "key_sharing_endpoint_provide_app_names": true,
   "validate_service_links": true,
   "optout_s3_bucket": "test-optout-bucket",

--- a/conf/local-e2e-docker-public-config.json
+++ b/conf/local-e2e-docker-public-config.json
@@ -25,6 +25,7 @@
   "client_side_token_generate_domain_name_check_enabled": true,
   "client_side_token_generate_log_invalid_http_origins": true,
   "key_sharing_endpoint_provide_site_domain_names": true,
+  "key_sharing_endpoint_provide_app_names": true,
   "validate_service_links": true,
   "optout_s3_bucket": "test-optout-bucket",
   "optout_s3_folder": "optout-v2/",

--- a/conf/local-e2e-public-config.json
+++ b/conf/local-e2e-public-config.json
@@ -38,6 +38,7 @@
   "client_side_token_generate": true,
   "client_side_token_generate_domain_name_check_enabled": true,
   "key_sharing_endpoint_provide_site_domain_names": true,
+  "key_sharing_endpoint_provide_app_names": true,
   "client_side_token_generate_log_invalid_http_origins": true,
   "salts_expired_shutdown_hours": 12
 }

--- a/conf/local-e2e-public-config.json
+++ b/conf/local-e2e-public-config.json
@@ -37,7 +37,6 @@
   "optout_partition_interval": 86400,
   "client_side_token_generate": true,
   "client_side_token_generate_domain_name_check_enabled": true,
-  "key_sharing_endpoint_provide_site_domain_names": true,
   "key_sharing_endpoint_provide_app_names": true,
   "client_side_token_generate_log_invalid_http_origins": true,
   "salts_expired_shutdown_hours": 12

--- a/conf/validator-latest-e2e-docker-public-config.json
+++ b/conf/validator-latest-e2e-docker-public-config.json
@@ -26,6 +26,7 @@
   "client_side_token_generate_domain_name_check_enabled": true,
   "client_side_token_generate_log_invalid_http_origins": true,
   "key_sharing_endpoint_provide_site_domain_names": true,
+  "key_sharing_endpoint_provide_app_names": true,
   "validate_service_links": true,
   "optout_s3_bucket": "test-optout-bucket",
   "optout_s3_folder": "optout-v2/",

--- a/conf/validator-latest-e2e-docker-public-config.json
+++ b/conf/validator-latest-e2e-docker-public-config.json
@@ -25,7 +25,6 @@
   "client_side_token_generate": true,
   "client_side_token_generate_domain_name_check_enabled": true,
   "client_side_token_generate_log_invalid_http_origins": true,
-  "key_sharing_endpoint_provide_site_domain_names": true,
   "key_sharing_endpoint_provide_app_names": true,
   "validate_service_links": true,
   "optout_s3_bucket": "test-optout-bucket",

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -764,11 +764,9 @@ public class UIDOperatorVerticle extends AbstractVerticle {
     private static JsonObject toJson(Site site, boolean includeAppNames) {
         JsonObject siteObj = new JsonObject();
         siteObj.put("id", site.getId());
-        Set<String> domainOrAppNames = new HashSet<>();
-        if (CollectionUtils.isNotEmpty(site.getDomainNames())) {
-            domainOrAppNames.addAll(site.getDomainNames());
-        }
-        if (includeAppNames && CollectionUtils.isNotEmpty(site.getAppNames())) {
+        Set<String> domainOrAppNames = new HashSet<>(site.getDomainNames());
+
+        if (includeAppNames) {
             domainOrAppNames.addAll(site.getAppNames());
         }
         siteObj.put("domain_names", domainOrAppNames.stream().sorted().collect(Collectors.toList()));

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -671,7 +671,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
     }
 
     private void addSites(JsonObject resp, List<KeysetKey> keys, Map<Integer, Keyset> keysetMap) {
-        final List<Site> sites = getSitesWithDomainAndAppNames(keys, keysetMap);
+        final List<Site> sites = getSitesWithDomainOrAppNames(keys, keysetMap);
         if (sites != null) {
             /*
             The end result will look something like this:
@@ -690,7 +690,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                             "101.co.uk",
                             "101.com",
                             "com.uid2.operator",
-                            "id123456789"
+                            "123456789"
                         ]
                     }
                 ]
@@ -735,7 +735,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
         resp.put("allow_clock_skew_seconds", allowClockSkewSeconds);
     }
 
-    private List<Site> getSitesWithDomainAndAppNames(List<KeysetKey> keys, Map<Integer, Keyset> keysetMap) {
+    private List<Site> getSitesWithDomainOrAppNames(List<KeysetKey> keys, Map<Integer, Keyset> keysetMap) {
         //without cstg enabled, operator won't have site data and siteProvider could be null
         if (!clientSideTokenGenerate) {
             return null;
@@ -748,10 +748,10 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                 .mapToObj(siteProvider::getSite)
                 .filter(Objects::nonNull)
                 .filter(site -> {
-                    if (!(CollectionUtils.isEmpty(site.getDomainNames()))) {
+                    if (CollectionUtils.isNotEmpty(site.getDomainNames())) {
                         return true;
                     } else {
-                        return keySharingEndpointProvideAppNames && !(CollectionUtils.isEmpty(site.getAppNames()));
+                        return keySharingEndpointProvideAppNames && CollectionUtils.isNotEmpty(site.getAppNames());
                     }
                 })
                 .collect(Collectors.toList());
@@ -765,13 +765,11 @@ public class UIDOperatorVerticle extends AbstractVerticle {
         JsonObject siteObj = new JsonObject();
         siteObj.put("id", site.getId());
         Set<String> domainOrAppNames = new HashSet<>();
-        if (!CollectionUtils.isEmpty(site.getDomainNames())) {
+        if (CollectionUtils.isNotEmpty(site.getDomainNames())) {
             domainOrAppNames.addAll(site.getDomainNames());
         }
-        if (includeAppNames) {
-            if (!CollectionUtils.isEmpty(site.getAppNames())) {
-                domainOrAppNames.addAll(site.getAppNames());
-            }
+        if (includeAppNames && CollectionUtils.isNotEmpty(site.getAppNames())) {
+            domainOrAppNames.addAll(site.getAppNames());
         }
         siteObj.put("domain_names", domainOrAppNames.stream().sorted().collect(Collectors.toList()));
         return siteObj;

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -50,6 +50,7 @@ import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.CorsHandler;
 import io.vertx.ext.web.handler.StaticHandler;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +63,7 @@ import java.security.*;
 import java.security.spec.*;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
-import java.util.*; 
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -753,9 +754,9 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                 .filter(Objects::nonNull)
                 .filter(site -> {
                     if (keySharingEndpointProvideAppNames) {
-                        return !(site.getDomainNames().isEmpty() && site.getAppNames().isEmpty());
+                        return !(CollectionUtils.isEmpty(site.getDomainNames()) && CollectionUtils.isEmpty(site.getAppNames()));
                     } else {
-                        return !site.getDomainNames().isEmpty();
+                        return !CollectionUtils.isEmpty(site.getDomainNames());
                     }
                 })
                 .collect(Collectors.toList());
@@ -769,11 +770,11 @@ public class UIDOperatorVerticle extends AbstractVerticle {
         JsonObject siteObj = new JsonObject();
         siteObj.put("id", site.getId());
         Set<String> domainOrAppNames = new HashSet<>();
-        if (!site.getDomainNames().isEmpty()) {
+        if (!CollectionUtils.isEmpty(site.getDomainNames())) {
             domainOrAppNames.addAll(site.getDomainNames());
         }
         if (keySharingEndpointProvideAppNames) {
-            if (!site.getAppNames().isEmpty()) {
+            if (!CollectionUtils.isEmpty(site.getAppNames())) {
                 domainOrAppNames.addAll(site.getAppNames());
             }
         }

--- a/src/main/resources/com.uid2.core/test/keyset_keys/keyset_keys.json
+++ b/src/main/resources/com.uid2.core/test/keyset_keys/keyset_keys.json
@@ -78,5 +78,13 @@
     "created": 1609459200,
     "activates": 1609469200,
     "expires": 4088629662
+  },
+  {
+    "id": 11,
+    "keyset_id": 901,
+    "secret": "YgyxOX4yX1gYhCINq7O9XxM6jX+etXqSXluZxjB1aG1=",
+    "created": 1713225363,
+    "activates": 1713250563,
+    "expires": 1715756163
   }
 ]

--- a/src/main/resources/com.uid2.core/test/keysets/keysets.json
+++ b/src/main/resources/com.uid2.core/test/keysets/keysets.json
@@ -136,5 +136,14 @@
     "keyset_id": 801,
     "name": "My keyset #5",
     "site_id": 8
+  },
+  {
+    "site_id": 127,
+    "name": "App Name Test Site Key Set 1",
+    "keyset_id": 901,
+    "default": true,
+    "created": 1713225363,
+    "enabled": true,
+    "allowed_sites": [123]
   }
 ]

--- a/src/main/resources/com.uid2.core/test/sites/sites.json
+++ b/src/main/resources/com.uid2.core/test/sites/sites.json
@@ -20,5 +20,12 @@
     "id": 126,
     "name": "AWS Venice",
     "enabled": true
+  },
+  {
+    "id": 127,
+    "name": "App Name Test Site",
+    "enabled": true,
+    "app_names" : ["com.uid2.operator", "id13456789"],
+    "domain_names" : ["example.com", "unifiedid.com"]
   }
 ]

--- a/src/main/resources/com.uid2.core/test/sites/sites.json
+++ b/src/main/resources/com.uid2.core/test/sites/sites.json
@@ -25,7 +25,7 @@
     "id": 127,
     "name": "App Name Test Site",
     "enabled": true,
-    "app_names" : ["com.uid2.operator", "id13456789"],
+    "app_names" : ["com.UID2.operator.TEST", "13456789"],
     "domain_names" : ["example.com", "unifiedid.com"]
   }
 ]

--- a/src/test/java/com/uid2/operator/ExtendedUIDOperatorVerticle.java
+++ b/src/test/java/com/uid2/operator/ExtendedUIDOperatorVerticle.java
@@ -40,6 +40,10 @@ public class ExtendedUIDOperatorVerticle extends UIDOperatorVerticle {
         this.keySharingEndpointProvideSiteDomainNames = enable;
     }
 
+    public void setKeySharingEndpointProvideAppNames(boolean enable) {
+        this.keySharingEndpointProvideAppNames = enable;
+    }
+
     public void setMaxSharingLifetimeSeconds(int maxSharingLifetimeSeconds) {
         this.maxSharingLifetimeSeconds = maxSharingLifetimeSeconds;
     }

--- a/src/test/java/com/uid2/operator/ExtendedUIDOperatorVerticle.java
+++ b/src/test/java/com/uid2/operator/ExtendedUIDOperatorVerticle.java
@@ -36,10 +36,6 @@ public class ExtendedUIDOperatorVerticle extends UIDOperatorVerticle {
         return this.idService;
     }
 
-    public void setKeySharingEndpointProvideSiteDomainNames(boolean enable) {
-        this.keySharingEndpointProvideSiteDomainNames = enable;
-    }
-
     public void setKeySharingEndpointProvideAppNames(boolean enable) {
         this.keySharingEndpointProvideAppNames = enable;
     }

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -4361,7 +4361,7 @@ public class UIDOperatorVerticleTest {
 
     public void verifyExpectedSiteDetail(Map<Integer, Site> expectedSites, JsonArray actualResult) {
 
-        assertEquals(actualResult.size(), expectedSites.size());
+        assertEquals(expectedSites.size(), actualResult.size());
         for(int i = 0; i < actualResult.size(); i++) {
 
             JsonObject siteDetail = actualResult.getJsonObject(i);
@@ -4378,7 +4378,7 @@ public class UIDOperatorVerticleTest {
                 assertTrue(actualDomainList.containsAll(expectedSite.getAppNames()));
                 size += expectedSite.getAppNames().size();
             }
-            assertEquals(actualDomainList.size(), size);
+            assertEquals(size, actualDomainList.size());
         }
     }
 

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -4371,15 +4371,10 @@ public class UIDOperatorVerticleTest {
             List<String> actualDomainList = (List<String>) siteDetail.getMap().get("domain_names");
             Site expectedSite = expectedSites.get(siteId);
             int size = 0;
-            if (!CollectionUtils.isEmpty(expectedSite.getDomainNames())) {
-                assertTrue(actualDomainList.containsAll(expectedSite.getDomainNames()));
-                size += expectedSite.getDomainNames().size();
-            }
-
-            if (!CollectionUtils.isEmpty(expectedSite.getAppNames())) {
-                assertTrue(actualDomainList.containsAll(expectedSite.getAppNames()));
-                size += expectedSite.getAppNames().size();
-            }
+            assertTrue(actualDomainList.containsAll(expectedSite.getDomainNames()));
+            size += expectedSite.getDomainNames().size();
+            assertTrue(actualDomainList.containsAll(expectedSite.getAppNames()));
+            size += expectedSite.getAppNames().size();
             assertEquals(size, actualDomainList.size());
         }
     }


### PR DESCRIPTION
Pending change : Updating shared version in pom.xml

Functionality is controlled behind flag `key_sharing_endpoint_provide_app_names`. The flag is disabled if the config is absent. In local config files, the flag is enabled. Also cleaned up old flag `key_sharing_endpoint_provide_site_domain_names`.

Example Request Response for bidstream
```
<edit Updated response below>
curl --location --request POST 'http://127.0.0.1:8080/v2/key/bidstream' \
--header 'Authorization: Bearer API_TOKEN' \
--data ''
RESPONSE
{
    "body": {
        "max_bidstream_lifetime_seconds": 3610,
        "identity_scope": "UID2",
        "allow_clock_skew_seconds": 1800,
        "keys": [
            {
                "id": 5,
                "created": 1609459200,
                "activates": 1609469200,
                "expires": 4088629662,
                "secret": "<secret>"
            },
            {
                "id": 11,
                "created": 1713225363,
                "activates": 1713250563,
                "expires": 1715756163,
                "secret": "<secret>"
            },
            {
                "id": 101,
                "created": 1622691044,
                "activates": 1687635529,
                "expires": 4088629662,
                "secret": "<secret>"
            },
            {
                "id": 104,
                "created": 1633991166,
                "activates": 1634077566,
                "expires": 4088629662,
                "secret": "<secret>"
            }
        ],
        "site_data": [
            {
                "id": 123,
                "domain_names": [
                    "localhost",
                    "uidapi.com"
                ]
            },
            {
                "id": 127,
                "domain_names": [
                    "13456789",
                    "com.UID2.operator.TEST",
                    "example.com",
                    "unifiedid.com"
                ]
            }
        ]
    },
    "status": "success"
}
```

Example request response for key/sharing endpoint
```
curl --location --request POST 'http://127.0.0.1:8080/v2/key/sharing' \
--header 'Authorization: Bearer API_TOKEN' \
--data ''
RESPONSE
{
    "body": {
        "caller_site_id": 123,
        "master_keyset_id": 9999999,
        "default_keyset_id": 501,
        "token_expiry_seconds": "2592000",
        "identity_scope": "UID2",
        "allow_clock_skew_seconds": 1800,
        "keys": [
            {
                "id": 5,
                "created": 1609459200,
                "activates": 1609469200,
                "expires": 4088629662,
                "secret": "<secret>",
                "keyset_id": 502
            },
            {
                "id": 11,
                "created": 1713225363,
                "activates": 1713250563,
                "expires": 1715756163,
                "secret": "<secret>"
            },
            {
                "id": 101,
                "created": 1622691044,
                "activates": 1687635529,
                "expires": 4088629662,
                "secret": "<secret>",
                "keyset_id": 9999999
            },
            {
                "id": 104,
                "created": 1633991166,
                "activates": 1634077566,
                "expires": 4088629662,
                "secret": "<secret>",
                "keyset_id": 501
            }
        ],
        "site_data": [
            {
                "id": 123,
                "domain_names": [
                    "localhost",
                    "uidapi.com"
                ]
            },
            {
                "id": 127,
                "domain_names": [
                    "13456789",
                    "com.UID2.operator.TEST",
                    "example.com",
                    "unifiedid.com"
                ]
            }
        ]
    },
    "status": "success"
}
```