### PR TITLE
CSTG: Validate app name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <enclave-aws.version>2.0.0-f7c174410e</enclave-aws.version>
         <enclave-azure.version>2.0.4-ef52553c57</enclave-azure.version>
         <enclave-gcp.version>2.0.0-21f950573a</enclave-gcp.version>
-        <uid2-shared.version>7.7.6-1e644a0ded-SNAPSHOT</uid2-shared.version>
+        <uid2-shared.version>7.9.0</uid2-shared.version>
         <image.version>${project.version}</image.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <enclave-aws.version>2.0.0-f7c174410e</enclave-aws.version>
         <enclave-azure.version>2.0.4-ef52553c57</enclave-azure.version>
         <enclave-gcp.version>2.0.0-21f950573a</enclave-gcp.version>
-        <uid2-shared.version>7.3.0-0c9c5b24fe</uid2-shared.version>
+        <uid2-shared.version>7.7.6-1e644a0ded-SNAPSHOT</uid2-shared.version>
         <image.version>${project.version}</image.version>
     </properties>
 

--- a/src/main/java/com/uid2/operator/model/CstgRequest.java
+++ b/src/main/java/com/uid2/operator/model/CstgRequest.java
@@ -11,6 +11,9 @@ public class CstgRequest {
     private String publicKey;
     private long timestamp;
 
+    @JsonProperty("app_name")
+    private String appName;
+
     public String getPayload() {
         return payload;
     }
@@ -29,6 +32,10 @@ public class CstgRequest {
 
     public long getTimestamp() {
         return timestamp;
+    }
+
+    public String getAppName() {
+        return appName;
     }
 }
 

--- a/src/main/java/com/uid2/operator/monitoring/TokenResponseStatsCollector.java
+++ b/src/main/java/com/uid2/operator/monitoring/TokenResponseStatsCollector.java
@@ -31,6 +31,7 @@ public class TokenResponseStatsCollector {
         BadPublicKey,
         BadSubscriptionId,
         InvalidHttpOrigin,
+        InvalidAppName,
         BadIV,
         BadPayload, //the actual cstg payload in the JSON request 
         BadJsonPayload, // can't even deserialise the JSON payload 

--- a/src/main/java/com/uid2/operator/service/ResponseUtil.java
+++ b/src/main/java/com/uid2/operator/service/ResponseUtil.java
@@ -175,5 +175,6 @@ public class ResponseUtil {
         public static final String UnknownError = "unknown";
         public static final String InsufficientUserConsent = "insufficient_user_consent";
         public static final String InvalidHttpOrigin = "invalid_http_origin";
+        public static final String InvalidAppName = "invalid_app_name";
     }
 }

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -1934,29 +1934,15 @@ public class UIDOperatorVerticle extends AbstractVerticle {
     }
 
     private String generateInvalidOriginAndAppNameMessage(Map<Integer, Set<String>> siteIdToInvalidOriginsAndAppNames) {
-        StringBuilder invalidHttpOriginMessage = new StringBuilder();
-        invalidHttpOriginMessage.append("InvalidHttpOriginAndAppName: ");
-        boolean mapHasFirstElement = false;
+        List<String> logEntries = new ArrayList<>();
         for (Map.Entry<Integer, Set<String>> entry : siteIdToInvalidOriginsAndAppNames.entrySet()) {
-            if(mapHasFirstElement) {
-                invalidHttpOriginMessage.append(" | ");
-            }
-            mapHasFirstElement = true;
             int siteId = entry.getKey();
             Set<String> origins = entry.getValue();
             String siteName = getSiteName(siteProvider, siteId);
-            String site = "site " + siteName + " (" + siteId + "): ";
-            invalidHttpOriginMessage.append(site);
-            boolean setHasFirstElement = false;
-            for (String origin : origins) {
-                if(setHasFirstElement) {
-                    invalidHttpOriginMessage.append(", ");
-                }
-                setHasFirstElement = true;
-                invalidHttpOriginMessage.append(origin);
-            }
+            logEntries.add("site " + siteName + " (" + siteId + "): " + String.join(", ", origins));
         }
-        return invalidHttpOriginMessage.toString();
+        return "InvalidHttpOriginAndAppName: " +
+                String.join(" | ", logEntries);
     }
 
     public enum UserConsentStatus {

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -1928,17 +1928,16 @@ public class UIDOperatorVerticle extends AbstractVerticle {
 
         if (Duration.between(lastInvalidOriginProcessTime, Instant.now()).compareTo(Duration.ofMinutes(60)) >= 0) {
             lastInvalidOriginProcessTime = Instant.now();
-            // Leaving the format of the log message unchanged for now, but logging invalid app names.
-            LOGGER.error(generateInvalidHttpOriginMessage(siteIdToInvalidOriginsAndAppNames));
+            LOGGER.error(generateInvalidOriginAndAppNameMessage(siteIdToInvalidOriginsAndAppNames));
             siteIdToInvalidOriginsAndAppNames.clear();
         }
     }
 
-    private String generateInvalidHttpOriginMessage(Map<Integer, Set<String>> siteIdToInvalidOrigins) {
+    private String generateInvalidOriginAndAppNameMessage(Map<Integer, Set<String>> siteIdToInvalidOriginsAndAppNames) {
         StringBuilder invalidHttpOriginMessage = new StringBuilder();
-        invalidHttpOriginMessage.append("InvalidHttpOrigin: ");
+        invalidHttpOriginMessage.append("InvalidHttpOriginAndAppName: ");
         boolean mapHasFirstElement = false;
-        for (Map.Entry<Integer, Set<String>> entry : siteIdToInvalidOrigins.entrySet()) {
+        for (Map.Entry<Integer, Set<String>> entry : siteIdToInvalidOriginsAndAppNames.entrySet()) {
             if(mapHasFirstElement) {
                 invalidHttpOriginMessage.append(" | ");
             }

--- a/src/main/resources/com.uid2.core/test/sites/sites.json
+++ b/src/main/resources/com.uid2.core/test/sites/sites.json
@@ -3,7 +3,8 @@
     "id": 123,
     "name": "MegaTest Site",
     "enabled": true,
-    "domain_names" : ["localhost", "uidapi.com"]
+    "domain_names" : ["localhost", "uidapi.com"],
+    "app_names": ["com.123.Game.App.android", "123456789", "com.123.Game.App.ios", "com.uid2.devapp"]
   },
   {
     "id": 124,

--- a/src/test/java/com/uid2/operator/ExtendedUIDOperatorVerticle.java
+++ b/src/test/java/com/uid2/operator/ExtendedUIDOperatorVerticle.java
@@ -46,7 +46,7 @@ public class ExtendedUIDOperatorVerticle extends UIDOperatorVerticle {
         this.lastInvalidOriginProcessTime = lastInvalidOriginProcessTime;
     }
 
-    public void setSiteIdToInvalidOrigins(Map<Integer, Set<String>> siteIdToInvalidOrigins) {
-        this.siteIdToInvalidOriginsAndAppNames = siteIdToInvalidOrigins;
+    public void setSiteIdToInvalidOriginsAndAppNames(Map<Integer, Set<String>> siteIdToInvalidOriginsAndAppNames) {
+        this.siteIdToInvalidOriginsAndAppNames = siteIdToInvalidOriginsAndAppNames;
     }
 }

--- a/src/test/java/com/uid2/operator/ExtendedUIDOperatorVerticle.java
+++ b/src/test/java/com/uid2/operator/ExtendedUIDOperatorVerticle.java
@@ -47,6 +47,6 @@ public class ExtendedUIDOperatorVerticle extends UIDOperatorVerticle {
     }
 
     public void setSiteIdToInvalidOrigins(Map<Integer, Set<String>> siteIdToInvalidOrigins) {
-        this.siteIdToInvalidOrigins = siteIdToInvalidOrigins;
+        this.siteIdToInvalidOriginsAndAppNames = siteIdToInvalidOrigins;
     }
 }

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -2809,7 +2809,7 @@ public class UIDOperatorVerticleTest {
                     assertFalse(respJson.containsKey("body"));
                     assertEquals("unexpected http origin", respJson.getString("message"));
                     assertEquals("invalid_http_origin", respJson.getString("status"));
-                    Assertions.assertTrue(logWatcher.list.get(0).getFormattedMessage().contains("InvalidHttpOrigin: site test (123): http://gototest.com"));
+                    Assertions.assertTrue(logWatcher.list.get(0).getFormattedMessage().contains("InvalidHttpOriginAndAppName: site test (123): http://gototest.com"));
                     assertTokenStatusMetrics(
                             clientSideTokenGenerateSiteId,
                             TokenResponseStatsCollector.Endpoint.ClientSideTokenGenerateV2,
@@ -2833,7 +2833,7 @@ public class UIDOperatorVerticleTest {
         siteIdToInvalidOrigins.put(clientSideTokenGenerateSiteId, new HashSet<>(Arrays.asList("http://localhost1.com", "http://localhost2.com")));
         siteIdToInvalidOrigins.put(124, new HashSet<>(Arrays.asList("http://xyz1.com", "http://xyz2.com")));
 
-        this.uidOperatorVerticle.setSiteIdToInvalidOrigins(siteIdToInvalidOrigins);
+        this.uidOperatorVerticle.setSiteIdToInvalidOriginsAndAppNames(siteIdToInvalidOrigins);
 
         setupCstgBackend();
         when(siteProvider.getSite(124)).thenReturn(new Site(124, "test2", true, new HashSet<>()));
@@ -2850,7 +2850,7 @@ public class UIDOperatorVerticleTest {
                     assertFalse(respJson.containsKey("body"));
                     assertEquals("unexpected http origin", respJson.getString("message"));
                     assertEquals("invalid_http_origin", respJson.getString("status"));
-                    Assertions.assertTrue(logWatcher.list.get(0).getFormattedMessage().contains("InvalidHttpOrigin: site test (123): http://localhost1.com, http://gototest.com, http://localhost2.com | site test2 (124): http://xyz1.com, http://xyz2.com"));
+                    Assertions.assertTrue(logWatcher.list.get(0).getFormattedMessage().contains("InvalidHttpOriginAndAppName: site test (123): http://localhost1.com, http://gototest.com, http://localhost2.com | site test2 (124): http://xyz1.com, http://xyz2.com"));
                     assertTokenStatusMetrics(
                             clientSideTokenGenerateSiteId,
                             TokenResponseStatsCollector.Endpoint.ClientSideTokenGenerateV2,


### PR DESCRIPTION
- App name is sent as part of the request payload.
- App name is part of the AAD.
- App name check is case insensitive.
- Invalid app names are logged together with invalid origins.
- App name check is controlled by the existing feature flag `client_side_token_generate_domain_name_check_enabled`.