### PR TITLE
Add site 999 in site 123's allowed_sites

### DIFF
--- a/src/main/resources/com.uid2.core/test/keysets/keysets.json
+++ b/src/main/resources/com.uid2.core/test/keysets/keysets.json
@@ -50,7 +50,8 @@
     "allowed_sites": [
       2,
       3,
-      4
+      4,
+      999
     ],
     "created": 1617149276,
     "default": true,
@@ -63,7 +64,8 @@
     "allowed_sites": [
       2,
       3,
-      4
+      4,
+      999
     ],
     "created": 1617149276,
     "default": false,


### PR DESCRIPTION
When generating a local token with [client_side_keypairs.json](https://github.com/IABTechLab/uid2-operator/blob/8989d27f47d4a24e7aa10615a019bed37c40b60a/src/main/resources/com.uid2.core/test/client_side_keypairs/client_side_keypairs.json#L4) and configuring the `BidstreamClient` in the SDK with API key and secret from [clients.json](https://github.com/IABTechLab/uid2-operator/blob/main/src/main/resources/com.uid2.core/test/clients/clients.json#L3), the `decryptTokenIntoRawUid()` method returned a `NOT_AUTHORIZED_FOR_KEY` error. This occurred because the site of the API key need to belong to `allowed_sites` or its type belongs to `allowed_types` of the site that generated the token. To address this issue, I included site 999 in the allowed_sites of site 123.