### PR TITLE
Add a delay container start

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.32.1-alpha-105-SNAPSHOT</version>
+    <version>5.32.2-alpha-106-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/scripts/azure-cc/entrypoint.sh
+++ b/scripts/azure-cc/entrypoint.sh
@@ -2,6 +2,22 @@
 #
 # This script must be compatible with Ash (provided in eclipse-temurin Docker image) and Bash
 
+function wait_for_sidecar() {
+  url="http://169.254.169.254/ping"
+  delay=1
+
+  while true; do
+    if curl -s --connect-timeout 5 "$url" > /dev/null; then
+      echo "side car started"
+      break
+    else
+      echo "side car not started. Retrying in $delay seconds..."
+      sleep $delay
+      delay=$((delay + 1))
+    fi
+  done
+}
+
 TMP_FINAL_CONFIG="/tmp/final-config.tmp"
 
 if [ -z "${VAULT_NAME}" ]; then
@@ -51,6 +67,9 @@ if [ -n "${CORE_BASE_URL}" -a -n "${OPTOUT_BASE_URL}" -a "${DEPLOYMENT_ENVIRONME
 fi
 
 cat $FINAL_CONFIG
+
+# delay the start of the operator until the side car has started correctly
+wait_for_sidecar
 
 # -- start operator
 echo "-- starting java application"

--- a/scripts/azure-cc/entrypoint.sh
+++ b/scripts/azure-cc/entrypoint.sh
@@ -7,7 +7,7 @@ function wait_for_sidecar() {
   delay=1
 
   while true; do
-    if curl -s --connect-timeout 5 "$url" > /dev/null; then
+    if wget -q --spider --tries=1 --timeout 5 "$url" > /dev/null; then
       echo "side car started"
       break
     else


### PR DESCRIPTION
Delaying the container start until after the sidecar allows the Java application to access the key vault. 