### PR TITLE
Add method OptOutStoreSnapshot.getAdIdOptOutTimestamp

### DIFF
--- a/conf/default-config.json
+++ b/conf/default-config.json
@@ -17,6 +17,8 @@
   "optout_partition_interval": 86400,
   "optout_max_partitions": 30,
   "optout_heap_default_capacity": 8192,
+  "optout_status_api_enabled": false,
+  "optout_status_max_request_size": 5000,
   "cloud_download_threads": 8,
   "cloud_upload_threads": 2,
   "cloud_refresh_interval": 60,

--- a/conf/local-config.json
+++ b/conf/local-config.json
@@ -32,6 +32,7 @@
   "optout_heap_default_capacity": 8192,
   "optout_max_partitions": 30,
   "optout_partition_interval": 86400,
+  "optout_status_api_enabled": true,
   "client_side_token_generate": true,
   "client_side_token_generate_domain_name_check_enabled": true,
   "key_sharing_endpoint_provide_app_names": true,

--- a/conf/local-e2e-docker-public-config.json
+++ b/conf/local-e2e-docker-public-config.json
@@ -31,6 +31,7 @@
   "optout_metadata_path": "/optout/refresh",
   "optout_api_uri": "http://optout:8081/optout/replicate",
   "optout_delta_rotate_interval": 60,
+  "optout_status_api_enabled": true,
   "cloud_refresh_interval": 30,
   "salts_expired_shutdown_hours": 12
 }

--- a/src/main/java/com/uid2/operator/Const.java
+++ b/src/main/java/com/uid2/operator/Const.java
@@ -23,5 +23,7 @@ public class Const extends com.uid2.shared.Const {
         public static final String AzureSecretNameProp = "azure_secret_name";
 
         public static final String GcpSecretVersionNameProp = "gcp_secret_version_name";
+        public static final String OptOutStatusApiEnabled = "optout_status_api_enabled";
+        public static final String OptOutStatusMaxRequestSize = "optout_status_max_request_size";
     }
 }

--- a/src/main/java/com/uid2/operator/Main.java
+++ b/src/main/java/com/uid2/operator/Main.java
@@ -140,7 +140,7 @@ public class Main {
         this.keysetProvider = new RotatingKeysetProvider(fsStores, new GlobalScope(new CloudPath(keysetMdPath)));
         String saltsMdPath = this.config.getString(Const.Config.SaltsMetadataPathProp);
         this.saltProvider = new RotatingSaltProvider(fsStores, saltsMdPath);
-        this.optOutStore = new CloudSyncOptOutStore(vertx, fsLocal, this.config, operatorKey);
+        this.optOutStore = new CloudSyncOptOutStore(vertx, fsLocal, this.config, operatorKey, Clock.systemUTC());
 
         if (this.validateServiceLinks) {
             String serviceMdPath = this.config.getString(Const.Config.ServiceMetadataPathProp);

--- a/src/main/java/com/uid2/operator/store/CloudSyncOptOutStore.java
+++ b/src/main/java/com/uid2/operator/store/CloudSyncOptOutStore.java
@@ -35,6 +35,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -326,6 +327,7 @@ public class CloudSyncOptOutStore implements IOptOutStore {
         private static final AtomicLong bloomFilterSize = new AtomicLong(0);
         private static final AtomicLong bloomFilterMax = new AtomicLong(0);
         private static final AtomicLong totalEntries = new AtomicLong(0);
+        private static final BiFunction<Long, Long, Long> OPT_OUT_TIMESTAMP_MERGE_STRATEGY = Long::min;
 
         private final DownloadCloudStorage fsLocal;
 
@@ -335,6 +337,12 @@ public class CloudSyncOptOutStore implements IOptOutStore {
 
         // a bloom filter to help optimizing the non-existing case for optout entry lookup
         private final BloomFilter bloomFilter;
+
+
+        /**
+         * A map from advertising IDs to optout timestamps.
+         */
+        private final Map<String, Long> adIdToOptOutTimestamp;
 
         // array of optout partitions
         private final OptOutPartition[] partitions;
@@ -364,6 +372,8 @@ public class CloudSyncOptOutStore implements IOptOutStore {
             int heapCapacity = jsonConfig.getInteger(Const.Config.OptOutHeapDefaultCapacityProp);
             this.heap = new OptOutHeap(heapCapacity);
 
+            this.adIdToOptOutTimestamp = Collections.emptyMap();
+
             // initially 1 partition
             this.partitions = new OptOutPartition[1];
             // First partition intentionally null.
@@ -390,6 +400,15 @@ public class CloudSyncOptOutStore implements IOptOutStore {
             newIndexedFiles.addAll(iuc.loadedPartitions.keySet());
             this.indexedFiles = Collections.unmodifiableSet(newIndexedFiles);
 
+            HashMap<String, Long> newOptOutTimestamps = new HashMap<>();
+            for (OptOutPartition partition : this.partitions) {
+                if (partition == null) continue;
+                partition.forEach(entry -> {
+                    newOptOutTimestamps.merge(entry.advertisingIdToB64(), entry.timestamp, OPT_OUT_TIMESTAMP_MERGE_STRATEGY);
+                });
+            }
+            this.adIdToOptOutTimestamp = Collections.unmodifiableMap(newOptOutTimestamps);
+
             // update total entries
             totalEntries.set(size());
         }
@@ -405,6 +424,10 @@ public class CloudSyncOptOutStore implements IOptOutStore {
         public boolean isHealthy(Instant now) {
             // index is healthy if it is updated within 3 * logRotationInterval
             return lastUpdatedTimestamp.get().plusSeconds(fileUtils.lookbackGracePeriod()).isAfter(now);
+        }
+
+        public long getAdIdOptOutTimestamp(String advertisingId) {
+            return this.adIdToOptOutTimestamp.getOrDefault(advertisingId, -1L);
         }
 
         // method provided for OptOutService to call

--- a/src/main/java/com/uid2/operator/store/CloudSyncOptOutStore.java
+++ b/src/main/java/com/uid2/operator/store/CloudSyncOptOutStore.java
@@ -389,8 +389,8 @@ public class CloudSyncOptOutStore implements IOptOutStore {
 
         public long size() {
             return Arrays.stream(this.partitions)
-                .<Long>map(p -> (long)p.size())
-                .reduce(0L, (a, b) -> a + b);
+                .mapToLong(OptOutPartition::size)
+                .sum();
         }
 
         // method provided for OptOutService to assess health
@@ -655,8 +655,8 @@ public class CloudSyncOptOutStore implements IOptOutStore {
 
         private BloomFilter newBloomFilter(OptOutPartition[] newPartitions) {
             long newSize = Arrays.stream(newPartitions)
-                .<Long>map(p -> (long)p.size())
-                .reduce(0L, (a, b) -> a + b);
+                .mapToLong(OptOutPartition::size)
+                .sum();
 
             BloomFilter bf = this.bloomFilter;
             if (bf.capacity() < newSize || bf.load() > 0.1) {

--- a/src/main/java/com/uid2/operator/store/CloudSyncOptOutStore.java
+++ b/src/main/java/com/uid2/operator/store/CloudSyncOptOutStore.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
@@ -49,7 +50,7 @@ public class CloudSyncOptOutStore implements IOptOutStore {
     private final String remoteApiPath;
     private final String remoteApiBearerToken;
 
-    public CloudSyncOptOutStore(Vertx vertx, ICloudStorage fsLocal, JsonObject jsonConfig, String operatorKey) throws MalformedURLException {
+    public CloudSyncOptOutStore(Vertx vertx, ICloudStorage fsLocal, JsonObject jsonConfig, String operatorKey, Clock clock) throws MalformedURLException {
         this.fsLocal = fsLocal;
         this.webClient = WebClient.create(vertx);
 
@@ -67,7 +68,7 @@ public class CloudSyncOptOutStore implements IOptOutStore {
             this.remoteApiBearerToken = null;
         }
 
-        this.snapshot.set(new OptOutStoreSnapshot(fsLocal, jsonConfig));
+        this.snapshot.set(new OptOutStoreSnapshot(fsLocal, jsonConfig, clock));
     }
 
     @Override
@@ -345,7 +346,10 @@ public class CloudSyncOptOutStore implements IOptOutStore {
 
         private final FileUtils fileUtils;
 
-        public OptOutStoreSnapshot(DownloadCloudStorage fsLocal, JsonObject jsonConfig) {
+        private final Clock clock;
+
+        public OptOutStoreSnapshot(DownloadCloudStorage fsLocal, JsonObject jsonConfig, Clock clock) {
+            this.clock = clock;
             this.fsLocal = fsLocal;
             this.fileUtils = new FileUtils(jsonConfig);
 
@@ -370,6 +374,7 @@ public class CloudSyncOptOutStore implements IOptOutStore {
 
         public OptOutStoreSnapshot(OptOutStoreSnapshot last, BloomFilter bf, OptOutHeap heap,
                                    OptOutPartition[] newPartitions, IndexUpdateContext iuc) {
+            this.clock = last.clock;
             this.fsLocal = last.fsLocal;
             this.fileUtils = last.fileUtils;
             this.iteration = last.iteration + 1;
@@ -422,7 +427,7 @@ public class CloudSyncOptOutStore implements IOptOutStore {
         }
 
         public OptOutStoreSnapshot updateIndex(Collection<String> cachedPath) throws IOException, CloudStorageException {
-            IndexUpdateMessage ium = this.getIndexUpdateMessage(Instant.now(), cachedPath);
+            IndexUpdateMessage ium = this.getIndexUpdateMessage(clock.instant(), cachedPath);
             return this.updateIndex(ium);
         }
 
@@ -472,7 +477,7 @@ public class CloudSyncOptOutStore implements IOptOutStore {
             // noop for EMPTY message
             if (ium.equals(IndexUpdateMessage.EMPTY)) {
                 // empty index update message also updates last updated timestamp
-                this.updateIndexTimestamp(Instant.now());
+                this.updateIndexTimestamp(clock.instant());
 
                 // empty message won't increase iteration counter
                 return this;

--- a/src/main/java/com/uid2/operator/store/CloudSyncOptOutStore.java
+++ b/src/main/java/com/uid2/operator/store/CloudSyncOptOutStore.java
@@ -8,6 +8,7 @@ import com.uid2.operator.model.UserIdentity;
 import com.uid2.operator.service.EncodingUtils;
 import com.uid2.shared.Utils;
 import com.uid2.shared.cloud.CloudStorageException;
+import com.uid2.shared.cloud.DownloadCloudStorage;
 import com.uid2.shared.cloud.ICloudStorage;
 import com.uid2.shared.cloud.MemCachedStorage;
 import com.uid2.shared.optout.*;
@@ -325,7 +326,7 @@ public class CloudSyncOptOutStore implements IOptOutStore {
         private static final AtomicLong bloomFilterMax = new AtomicLong(0);
         private static final AtomicLong totalEntries = new AtomicLong(0);
 
-        private final ICloudStorage fsLocal;
+        private final DownloadCloudStorage fsLocal;
 
         // holds a heap data structure for unsorted optout entries
         // a new optout log will be produced at a regular interval (5mins), which will be loaded to heap
@@ -344,7 +345,7 @@ public class CloudSyncOptOutStore implements IOptOutStore {
 
         private final FileUtils fileUtils;
 
-        public OptOutStoreSnapshot(ICloudStorage fsLocal, JsonObject jsonConfig) {
+        public OptOutStoreSnapshot(DownloadCloudStorage fsLocal, JsonObject jsonConfig) {
             this.fsLocal = fsLocal;
             this.fileUtils = new FileUtils(jsonConfig);
 

--- a/src/main/java/com/uid2/operator/store/CloudSyncOptOutStore.java
+++ b/src/main/java/com/uid2/operator/store/CloudSyncOptOutStore.java
@@ -365,7 +365,7 @@ public class CloudSyncOptOutStore implements IOptOutStore {
             this.partitions[0] = this.heap.toPartition(true);
 
             // initially no indexed files
-            this.indexedFiles = Collections.unmodifiableSet(new HashSet<>());
+            this.indexedFiles = Collections.emptySet();
         }
 
         public OptOutStoreSnapshot(OptOutStoreSnapshot last, BloomFilter bf, OptOutHeap heap,

--- a/src/main/java/com/uid2/operator/store/IOptOutStore.java
+++ b/src/main/java/com/uid2/operator/store/IOptOutStore.java
@@ -15,5 +15,7 @@ public interface IOptOutStore {
      */
     Instant getLatestEntry(UserIdentity firstLevelHashIdentity);
 
+    long getOptOutTimestampByAdId(String adId);
+
     void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, Handler<AsyncResult<Instant>> handler);
 }

--- a/src/test/java/com/uid2/operator/benchmark/BenchmarkCommon.java
+++ b/src/test/java/com/uid2/operator/benchmark/BenchmarkCommon.java
@@ -197,6 +197,11 @@ public class BenchmarkCommon {
         public void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, Handler<AsyncResult<Instant>> handler) {
             // noop
         }
+
+        @Override
+        public long getOptOutTimestampByAdId(String adId) {
+            return -1;
+        }
     }
 
 }

--- a/src/test/java/com/uid2/operator/benchmark/BenchmarkCommon.java
+++ b/src/test/java/com/uid2/operator/benchmark/BenchmarkCommon.java
@@ -181,7 +181,7 @@ public class BenchmarkCommon {
         private CloudSyncOptOutStore.OptOutStoreSnapshot snapshot;
 
         public StaticOptOutStore(ICloudStorage storage, JsonObject jsonConfig, Collection<String> partitions) throws CloudStorageException, IOException {
-            snapshot = new CloudSyncOptOutStore.OptOutStoreSnapshot(storage, jsonConfig);
+            snapshot = new CloudSyncOptOutStore.OptOutStoreSnapshot(storage, jsonConfig, Clock.systemUTC());
             snapshot = snapshot.updateIndex(partitions);
             System.out.println(snapshot.size());
         }

--- a/src/test/java/com/uid2/operator/store/OptOutStoreSnapshotTest.java
+++ b/src/test/java/com/uid2/operator/store/OptOutStoreSnapshotTest.java
@@ -1,0 +1,157 @@
+package com.uid2.operator.store;
+
+import com.uid2.operator.Const;
+import com.uid2.shared.cloud.CloudStorageException;
+import com.uid2.shared.cloud.DownloadCloudStorage;
+import com.uid2.shared.cloud.MemCachedStorage;
+import com.uid2.shared.optout.OptOutConst;
+import com.uid2.shared.optout.OptOutEntry;
+import com.uid2.shared.optout.OptOutUtils;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.mock;
+
+class OptOutStoreSnapshotTest {
+    @Nested
+    class GetAdIdOptOutTimestamp {
+        @Test
+        void emptySnapshotReturnsNegativeOne() {
+            DownloadCloudStorage fsStore = mock(DownloadCloudStorage.class);
+            JsonObject config = make1mOptOutEntryConfig();
+            CloudSyncOptOutStore.OptOutStoreSnapshot snapshot = new CloudSyncOptOutStore.OptOutStoreSnapshot(fsStore, config, Clock.systemUTC());
+            assertEquals(-1L, snapshot.getAdIdOptOutTimestamp(OptOutEntry.newRandom().advertisingIdToB64()));
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "1,1",
+                "10,1",
+                "10,10"
+        })
+        void emptySnapshotUpdatedWithDeltaFilesReturnsCorrectTimestamps(int deltaFileCount, int entriesPerDeltaFileCount) throws CloudStorageException, IOException {
+            assumeTrue(deltaFileCount > 0);
+            assumeTrue(entriesPerDeltaFileCount > 0);
+
+            // Arrange
+            Clock clock = Clock.fixed(Instant.parse("2024-05-06T10:15:30.00Z"), ZoneOffset.UTC);
+
+            MemCachedStorage fsStore = new MemCachedStorage();
+
+            List<OptOutEntry> entries = new ArrayList<>();
+
+            for (int i = 0; i < deltaFileCount; i++) {
+                Instant deltaFileTimestamp = clock.instant()
+                        .minus(deltaFileCount, ChronoUnit.HOURS);
+
+                List<OptOutEntry> deltaEntries = createDelta(entriesPerDeltaFileCount, deltaFileTimestamp, fsStore);
+                entries.addAll(deltaEntries);
+            }
+
+            Set<String> paths = new HashSet<>(fsStore.list(OptOutUtils.prefixDeltaFile));
+
+            JsonObject config = make1mOptOutEntryConfig();
+
+            // Act
+            CloudSyncOptOutStore.OptOutStoreSnapshot snapshot = new CloudSyncOptOutStore.OptOutStoreSnapshot(fsStore, config, clock)
+                    .updateIndex(paths);
+
+            // Assert
+            for (OptOutEntry entry : entries) {
+                assertEquals(entry.timestamp, snapshot.getAdIdOptOutTimestamp(entry.advertisingIdToB64()));
+            }
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "1,1",
+                "10,1",
+                "10,10"
+        })
+        void emptySnapshotUpdatedWithPartitionFilesReturnsCorrectTimestamps(int partitionFileCount, int entriesPerPartitionFileCount) throws CloudStorageException, IOException {
+            assumeTrue(partitionFileCount > 0);
+            assumeTrue(entriesPerPartitionFileCount > 0);
+
+            // Arrange
+            Clock clock = Clock.fixed(Instant.parse("2024-05-06T10:15:30.00Z"), ZoneOffset.UTC);
+
+            MemCachedStorage fsStore = new MemCachedStorage();
+
+            List<OptOutEntry> entries = new ArrayList<>();
+
+            for (int i = 0; i < partitionFileCount; i++) {
+                Instant partitionTimestamp = clock.instant()
+                        .minus(i, ChronoUnit.DAYS);
+
+                List<OptOutEntry> partitionEntries = createPartition(entriesPerPartitionFileCount, partitionTimestamp, fsStore);
+                entries.addAll(partitionEntries);
+            }
+
+            Set<String> paths = new HashSet<>(fsStore.list(OptOutUtils.prefixPartitionFile));
+
+            JsonObject config = make1mOptOutEntryConfig();
+
+            // Act
+            CloudSyncOptOutStore.OptOutStoreSnapshot snapshot = new CloudSyncOptOutStore.OptOutStoreSnapshot(fsStore, config, clock)
+                    .updateIndex(paths);
+
+            // Assert
+            for (OptOutEntry entry : entries) {
+                assertEquals(entry.timestamp, snapshot.getAdIdOptOutTimestamp(entry.advertisingIdToB64()));
+            }
+        }
+
+        private List<OptOutEntry> createDelta(int entriesCount, Instant timestamp, MemCachedStorage fsStore) throws CloudStorageException {
+            return createDeltaOrPartition(entriesCount, timestamp, fsStore, OptOutUtils.newDeltaFileName(timestamp));
+        }
+
+        private List<OptOutEntry> createPartition(int entriesCount, Instant timestamp, MemCachedStorage fsStore) throws CloudStorageException {
+            return createDeltaOrPartition(entriesCount, timestamp, fsStore, OptOutUtils.newPartitionFileName(timestamp));
+        }
+
+        private List<OptOutEntry> createDeltaOrPartition(int entriesCount, Instant timestamp, MemCachedStorage fsStore, String cloudPath) throws CloudStorageException {
+            List<OptOutEntry> entries = createEntries(timestamp, entriesCount);
+            fsStore.upload(new ByteArrayInputStream(entriesToByteArray(entries)), cloudPath);
+            return entries;
+        }
+
+        private List<OptOutEntry> createEntries(Instant timestamp, int count) {
+            List<OptOutEntry> entries = new ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                entries.add(OptOutEntry.newTestEntry(timestamp.plusSeconds(i).toEpochMilli(), timestamp.plusSeconds(i).toEpochMilli()));
+            }
+            return entries;
+        }
+
+        private byte[] entriesToByteArray(List<OptOutEntry> entries) {
+            byte[] bytes = new byte[OptOutConst.EntrySize * entries.size()];
+            for (int i = 0; i < entries.size(); i++) {
+                entries.get(i).copyToByteArray(bytes, OptOutConst.EntrySize * i);
+            }
+            return bytes;
+        }
+
+        private JsonObject make1mOptOutEntryConfig() {
+            final JsonObject config = new JsonObject();
+            config.put(Const.Config.OptOutBloomFilterSizeProp, 100000); // 1:10 bloomfilter
+            config.put(Const.Config.OptOutHeapDefaultCapacityProp, 1000000); // 1MM record
+            config.put("optout_delta_rotate_interval", 86400);
+            config.put("optout_partition_interval", 86400);
+            config.put("optout_max_partitions", 150);
+            return config;
+        }
+    }
+}


### PR DESCRIPTION
This method returns the earliest optout timestamp for a given advertising ID.

One commit is a workaround for an issue where calling `toPartition` on an empty heap throws an assertion error. This issue has laid dormant because we didn't have any tests covering `OptOutStoreSnapshot` until now. The workaround is to use `null` instead, so we need some extra checks.

Included are some small improvements:
- Use `sum` instead of `reduce` for clarity.
- Change type of `OptOutStoreSnapshot.fsLocal` from `ICloudStorage` to `DownloadCloudStorage` for easier testing.
- Pass a `Clock` to `OptOutStoreSnapshot` for easier testing.
