### PR TITLE
UID2-3406 Add logging for origin and referer to 4xx warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.34.0</version>
+    <version>5.34.1-alpha-77-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/uid2/operator/service/ResponseUtil.java
+++ b/src/main/java/com/uid2/operator/service/ResponseUtil.java
@@ -152,7 +152,7 @@ public class ResponseUtil {
     }
 
     private static void logWarning(String status, int statusCode, String message, RoutingContextReader contextReader, String clientAddress) {
-        String warnMessage = "Warning response to http request. " + JsonObject.of(
+        JsonObject warnMessageJsonObject = JsonObject.of(
                 "errorStatus", status,
                 "contact", contextReader.getContact(),
                 "siteId", contextReader.getSiteId(),
@@ -160,7 +160,18 @@ public class ResponseUtil {
                 "statusCode", statusCode,
                 "clientAddress", clientAddress,
                 "message", message
-        ).encode();
+        );
+        final String referer = contextReader.getReferer();
+        final String origin = contextReader.getOrigin();
+        if (statusCode >= 400 && statusCode < 500) {
+            if (referer != null) {
+                warnMessageJsonObject.put("referer", referer);
+            }
+            if (origin != null) {
+                warnMessageJsonObject.put("origin", origin);
+            }
+        }
+        String warnMessage = "Warning response to http request. " + warnMessageJsonObject.encode();
         LOGGER.warn(warnMessage);
     }
 

--- a/src/main/java/com/uid2/operator/service/RoutingContextReader.java
+++ b/src/main/java/com/uid2/operator/service/RoutingContextReader.java
@@ -13,6 +13,10 @@ public class RoutingContextReader {
         this.context = context;
     }
 
+    public String getOrigin() { return this.context.request().getHeader("origin"); }
+
+    public String getReferer() { return this.context.request().getHeader("referer"); }
+
     public Integer getSiteId() {
         final Integer siteId = context.get(Const.RoutingContextData.SiteId);
         if (siteId != null) {

--- a/src/test/java/com/uid2/operator/service/ResponseUtilTest.java
+++ b/src/test/java/com/uid2/operator/service/ResponseUtilTest.java
@@ -6,6 +6,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.uid2.shared.Const;
 import com.uid2.shared.auth.IAuthorizable;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +20,7 @@ class ResponseUtilTest {
     private Logger logger;
     private ListAppender<ILoggingEvent> testAppender;
     private RoutingContext rc;
+    private HttpServerRequest request;
 
     @BeforeEach
     void setUp() {
@@ -27,6 +29,7 @@ class ResponseUtilTest {
         testAppender.start();
         logger.addAppender(testAppender);
         rc = mock(RoutingContext.class, RETURNS_DEEP_STUBS);
+        request = mock(HttpServerRequest.class, RETURNS_DEEP_STUBS);
         when(rc.get(SecureLinkValidatorService.SERVICE_LINK_NAME, "")).thenReturn("");
         when(rc.get(SecureLinkValidatorService.SERVICE_NAME, "")).thenReturn("");
     }
@@ -131,6 +134,88 @@ class ResponseUtilTest {
                 "\"message\":\"Some error message\"," +
                 "\"service_link_name\":\"TestLink1\"," +
                 "\"service_name\":\"TestService1\"" +
+                "}";
+        ILoggingEvent loggingEvent = testAppender.list.get(0);
+        assertThat(loggingEvent.getMessage()).isEqualTo(expected);
+    }
+
+    @Test
+    void logsWarningWithOrigin() {
+        when(request.getHeader("origin")).thenReturn("testOriginHeader");
+        when(rc.request()).thenReturn(request);
+
+        ResponseUtil.Warning("Some error status", 400, rc, "Some error message");
+
+        String expected = "Warning response to http request. {" +
+                "\"errorStatus\":\"Some error status\"," +
+                "\"contact\":null," +
+                "\"siteId\":null," +
+                "\"path\":null," +
+                "\"statusCode\":400," +
+                "\"clientAddress\":null," +
+                "\"message\":\"Some error message\"," +
+                "\"origin\":\"testOriginHeader\"" +
+                "}";
+        ILoggingEvent loggingEvent = testAppender.list.get(0);
+        assertThat(loggingEvent.getMessage()).isEqualTo(expected);
+    }
+
+    @Test
+    void logsWarningWithOriginNull() {
+        when(request.getHeader("origin")).thenReturn(null);
+        when(rc.request()).thenReturn(request);
+
+        ResponseUtil.Warning("Some error status", 400, rc, "Some error message");
+
+        String expected = "Warning response to http request. {" +
+                "\"errorStatus\":\"Some error status\"," +
+                "\"contact\":null," +
+                "\"siteId\":null," +
+                "\"path\":null," +
+                "\"statusCode\":400," +
+                "\"clientAddress\":null," +
+                "\"message\":\"Some error message\"" +
+                "}";
+        ILoggingEvent loggingEvent = testAppender.list.get(0);
+        assertThat(loggingEvent.getMessage()).isEqualTo(expected);
+    }
+
+    @Test
+    void logsWarningWithReferer() {
+        when(request.getHeader("referer")).thenReturn("testRefererHeader");
+        when(rc.request()).thenReturn(request);
+
+        ResponseUtil.Warning("Some error status", 400, rc, "Some error message");
+
+        String expected = "Warning response to http request. {" +
+                "\"errorStatus\":\"Some error status\"," +
+                "\"contact\":null," +
+                "\"siteId\":null," +
+                "\"path\":null," +
+                "\"statusCode\":400," +
+                "\"clientAddress\":null," +
+                "\"message\":\"Some error message\"," +
+                "\"referer\":\"testRefererHeader\"" +
+                "}";
+        ILoggingEvent loggingEvent = testAppender.list.get(0);
+        assertThat(loggingEvent.getMessage()).isEqualTo(expected);
+    }
+
+    @Test
+    void logsWarningWithRefererNull() {
+        when(request.getHeader("referer")).thenReturn(null);
+        when(rc.request()).thenReturn(request);
+
+        ResponseUtil.Warning("Some error status", 400, rc, "Some error message");
+
+        String expected = "Warning response to http request. {" +
+                "\"errorStatus\":\"Some error status\"," +
+                "\"contact\":null," +
+                "\"siteId\":null," +
+                "\"path\":null," +
+                "\"statusCode\":400," +
+                "\"clientAddress\":null," +
+                "\"message\":\"Some error message\"" +
                 "}";
         ILoggingEvent loggingEvent = testAppender.list.get(0);
         assertThat(loggingEvent.getMessage()).isEqualTo(expected);


### PR DESCRIPTION
Deployed to integ and tested it working: [dashboard](https://dash.uidapi.com/explore?orgId=1&left=%7B%22datasource%22:%22dADfYKrGk%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bapp%3D%5C%22uid2-operator%5C%22,%20host%3D%5C%22uid2-operator-integ-6bcbb4f66d-wjf7x%5C%22%7D%20%7C%3D%20%60%2Ftoken%2Frefresh%60%20%7C%3D%20%60%5C%22statusCode%5C%22:400%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22dADfYKrGk%22%7D,%22editorMode%22:%22builder%22%7D,%7B%22refId%22:%22B%22,%22expr%22:%22%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22dADfYKrGk%22%7D,%22editorMode%22:%22code%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%221716793816279%22,%22to%22:%221716794192488%22%7D%7D)
![image](https://github.com/IABTechLab/uid2-operator/assets/11983300/10bf30cc-f7cd-4b93-9a9f-00aeb09017f9)
