### PR TITLE
UID2-2904 removed old optout check flag in CSTG and always return optout response for opted out users in CSTG endpoint and also token/refresh calls from CSTG derived tokens

### DIFF
--- a/src/main/java/com/uid2/operator/service/UIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/UIDOperatorService.java
@@ -135,7 +135,6 @@ public class UIDOperatorService implements IUIDOperatorService {
 
         final PrivacyBits privacyBits = PrivacyBits.fromInt(token.userIdentity.privacyBits);
         final boolean isCstg = privacyBits.isClientSideTokenGenerated();
-        final boolean shouldCstgOptedOutUserReturnOptOutToken = !shouldCstgOptedOutUserReturnOptOutResponse(identityScope);
 
         try {
             final GlobalOptoutResult logoutEntry = getGlobalOptOutResult(token.userIdentity, true);
@@ -147,20 +146,6 @@ public class UIDOperatorService implements IUIDOperatorService {
                 IdentityTokens identityTokens = this.generateIdentity(token.publisherIdentity, token.userIdentity);
 
                 return RefreshResponse.createRefreshedResponse(identityTokens, durationSinceLastRefresh, isCstg);
-            } else if (isCstg && shouldCstgOptedOutUserReturnOptOutToken) {
-
-                // The user has opted out after the userIdentity was established.
-                privacyBits.setClientSideTokenGenerateOptout();
-
-                final UserIdentity cstgOptOutIdentity = getClientSideTokenGenerateOptOutInputVal(token.userIdentity.identityType)
-                        .toUserIdentity(identityScope, privacyBits.getAsInt(), now);
-
-                final IdentityTokens identityTokens = generateIdentity(
-                        new IdentityRequest(
-                                new PublisherIdentity(token.publisherIdentity.siteId, 0, 0),
-                                cstgOptOutIdentity, OptoutCheckPolicy.DoNotRespect));
-
-                return RefreshResponse.createRefreshedResponse(identityTokens, durationSinceLastRefresh, true);
             } else {
                 return RefreshResponse.Optout;
             }
@@ -361,11 +346,5 @@ public class UIDOperatorService implements IUIDOperatorService {
             return TokenVersion.V4;
         }
         return this.advertisingTokenV4Percentage == 100 ? TokenVersion.V4 : this.tokenVersionToUseIfNotV4;
-    }
-
-    public static boolean shouldCstgOptedOutUserReturnOptOutResponse(IdentityScope identityScope) {
-
-        //UID2-2904 both UID2/EUID should return optout response  
-        return true;
     }
 }

--- a/src/main/java/com/uid2/operator/service/UIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/UIDOperatorService.java
@@ -135,8 +135,7 @@ public class UIDOperatorService implements IUIDOperatorService {
 
         final PrivacyBits privacyBits = PrivacyBits.fromInt(token.userIdentity.privacyBits);
         final boolean isCstg = privacyBits.isClientSideTokenGenerated();
-        final boolean hasCstgOptOutCheckFlag = privacyBits.isClientSideTokenGenerateOptoutResponseOn();
-        final boolean shouldCstgOptedOutUserReturnOptOutToken = !shouldCstgOptedOutUserReturnOptOutResponse(identityScope, hasCstgOptOutCheckFlag);
+        final boolean shouldCstgOptedOutUserReturnOptOutToken = !shouldCstgOptedOutUserReturnOptOutResponse(identityScope);
 
         try {
             final GlobalOptoutResult logoutEntry = getGlobalOptOutResult(token.userIdentity, true);
@@ -364,11 +363,9 @@ public class UIDOperatorService implements IUIDOperatorService {
         return this.advertisingTokenV4Percentage == 100 ? TokenVersion.V4 : this.tokenVersionToUseIfNotV4;
     }
 
-    public static boolean shouldCstgOptedOutUserReturnOptOutResponse(IdentityScope identityScope,
-                                                                     boolean cstgRequestHasOptoutCheckFlag) {
-        if (identityScope == IdentityScope.EUID) {
-            return true;
-        }
-        return cstgRequestHasOptoutCheckFlag;
+    public static boolean shouldCstgOptedOutUserReturnOptOutResponse(IdentityScope identityScope) {
+
+        //UID2-2904 both UID2/EUID should return optout response  
+        return true;
     }
 }

--- a/src/main/java/com/uid2/operator/service/UIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/UIDOperatorService.java
@@ -156,26 +156,6 @@ public class UIDOperatorService implements IUIDOperatorService {
         }
     }
 
-    private static InputUtil.InputVal getClientSideTokenGenerateOptOutInputVal(IdentityType identityType) {
-        switch (identityType) {
-            case Email:
-                return InputUtil.InputVal.validEmail(
-                        OptOutTokenIdentityForEmail,
-                        OptOutTokenIdentityForEmail);
-            case Phone:
-                return InputUtil.InputVal.validPhone(
-                        OptOutTokenIdentityForPhone,
-                        OptOutTokenIdentityForPhone);
-            default:
-                // Assert will fire when this code path is hit by a test.
-                assert false: "Invalid identity type " + identityType;
-                // Provide a fallback value instead of throwing an exception.
-                return InputUtil.InputVal.validEmail(
-                        OptOutTokenIdentityForEmail,
-                        OptOutTokenIdentityForEmail);
-        }
-    }
-
     @Override
     public MappedIdentity mapIdentity(MapRequest request) {
         final UserIdentity firstLevelHashIdentity = getFirstLevelHashIdentity(request.userIdentity, request.asOf);

--- a/src/main/java/com/uid2/operator/util/PrivacyBits.java
+++ b/src/main/java/com/uid2/operator/util/PrivacyBits.java
@@ -6,7 +6,9 @@ public class PrivacyBits {
     private static final int BIT_LEGACY = 0;
     private static final int BIT_CSTG = 1;
     private static final int BIT_CSTG_OPTOUT = 2;
-
+    //DO NOT REUSE THIS BIT. DEPRECATED from UID2-2904 work
+    private static final int BIT_CSTG_OPTOUT_RESPONSE_DEPRECATED = 3;
+    
     private int bits = 0;
 
     public static PrivacyBits fromInt(int privacyBits) { return new PrivacyBits(privacyBits); }

--- a/src/main/java/com/uid2/operator/util/PrivacyBits.java
+++ b/src/main/java/com/uid2/operator/util/PrivacyBits.java
@@ -6,7 +6,6 @@ public class PrivacyBits {
     private static final int BIT_LEGACY = 0;
     private static final int BIT_CSTG = 1;
     private static final int BIT_CSTG_OPTOUT = 2;
-    private static final int BIT_CSTG_OPTOUT_RESPONSE = 3;
 
     private int bits = 0;
 
@@ -32,12 +31,7 @@ public class PrivacyBits {
     public boolean isClientSideTokenOptedOut() {
         return isBitSet(BIT_CSTG_OPTOUT);
     }
-
-    public void setClientSideTokenGenerateOptoutResponse() { setBit(BIT_CSTG_OPTOUT_RESPONSE); }
-    public boolean isClientSideTokenGenerateOptoutResponseOn() {
-        return isBitSet(BIT_CSTG_OPTOUT_RESPONSE);
-    }
-
+    
     public void setLegacyBit() {
         setBit(BIT_LEGACY);//unknown why this bit is set in https://github.com/IABTechLab/uid2-operator/blob/dbab58346e367c9d4122ad541ff9632dc37bd410/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java#L534
     }

--- a/src/main/java/com/uid2/operator/util/PrivacyBits.java
+++ b/src/main/java/com/uid2/operator/util/PrivacyBits.java
@@ -8,7 +8,7 @@ public class PrivacyBits {
     private static final int BIT_CSTG_OPTOUT = 2;
     //DO NOT REUSE THIS BIT. DEPRECATED from UID2-2904 work
     private static final int BIT_CSTG_OPTOUT_RESPONSE_DEPRECATED = 3;
-    
+
     private int bits = 0;
 
     public static PrivacyBits fromInt(int privacyBits) { return new PrivacyBits(privacyBits); }

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -427,8 +427,6 @@ public class UIDOperatorVerticle extends AbstractVerticle {
 
         final String emailHash = requestPayload.getString("email_hash");
         final String phoneHash = requestPayload.getString("phone_hash");
-        final int optoutCheck = requestPayload.getInteger("optout_check", 0);
-        final boolean cstgRequestHasOptoutCheckFlag = optoutCheck == OptoutCheckPolicy.RespectOptOut.ordinal();
         final InputUtil.InputVal input;
 
 
@@ -461,10 +459,6 @@ public class UIDOperatorVerticle extends AbstractVerticle {
         privacyBits.setLegacyBit();
         privacyBits.setClientSideTokenGenerate();
 
-        if(cstgRequestHasOptoutCheckFlag) {
-            privacyBits.setClientSideTokenGenerateOptoutResponse();
-        }
-
         IdentityTokens identityTokens;
         try {
             identityTokens = this.idService.generateIdentity(
@@ -480,7 +474,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
         TokenResponseStatsCollector.ResponseStatus responseStatus = TokenResponseStatsCollector.ResponseStatus.Success;
 
         if (identityTokens.isEmptyToken()) {
-            if (UIDOperatorService.shouldCstgOptedOutUserReturnOptOutResponse(identityScope, cstgRequestHasOptoutCheckFlag)) {
+            if (UIDOperatorService.shouldCstgOptedOutUserReturnOptOutResponse(identityScope)) {
                 response = ResponseUtil.SuccessNoBodyV2("optout");
                 responseStatus = TokenResponseStatsCollector.ResponseStatus.OptOut;
             }

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -474,16 +474,8 @@ public class UIDOperatorVerticle extends AbstractVerticle {
         TokenResponseStatsCollector.ResponseStatus responseStatus = TokenResponseStatsCollector.ResponseStatus.Success;
 
         if (identityTokens.isEmptyToken()) {
-            if (UIDOperatorService.shouldCstgOptedOutUserReturnOptOutResponse(identityScope)) {
-                response = ResponseUtil.SuccessNoBodyV2("optout");
-                responseStatus = TokenResponseStatsCollector.ResponseStatus.OptOut;
-            }
-            else {
-                privacyBits.setClientSideTokenGenerateOptout();
-                //user opted out we will generate an optout token with the opted out user identity
-                identityTokens = generateOptedOutIdentityTokens(privacyBits, input, clientSideKeypair);
-                response = ResponseUtil.SuccessV2(toJsonV1(identityTokens));
-            }
+            response = ResponseUtil.SuccessNoBodyV2("optout");
+            responseStatus = TokenResponseStatsCollector.ResponseStatus.OptOut;
         }
         else { //user not opted out and already generated valid identity token
             response = ResponseUtil.SuccessV2(toJsonV1(identityTokens));

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -552,19 +552,6 @@ public class UIDOperatorVerticle extends AbstractVerticle {
         }
     }
 
-    private IdentityTokens generateOptedOutIdentityTokens(PrivacyBits privacyBits, InputUtil.InputVal input, ClientSideKeypair clientSideKeypair) {
-        UserIdentity cstgOptOutIdentity;
-        if (input.getIdentityType() == IdentityType.Email) {
-            cstgOptOutIdentity = InputUtil.InputVal.validEmail(OptOutTokenIdentityForEmail, OptOutTokenIdentityForEmail).toUserIdentity(identityScope, privacyBits.getAsInt(), Instant.now());
-        } else {
-            cstgOptOutIdentity = InputUtil.InputVal.validPhone(OptOutTokenIdentityForPhone, OptOutTokenIdentityForPhone).toUserIdentity(identityScope, privacyBits.getAsInt(), Instant.now());
-        }
-        return this.idService.generateIdentity(
-                new IdentityRequest(
-                        new PublisherIdentity(clientSideKeypair.getSiteId(), 0, 0),
-                        cstgOptOutIdentity, OptoutCheckPolicy.DoNotRespect));
-    }
-
     private byte[] decrypt(byte[] encryptedBytes, int offset, byte[] secretBytes, byte[] aad) throws InvalidAlgorithmParameterException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
         SecretKey key = new SecretKeySpec(secretBytes, "AES");
         GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(128, encryptedBytes, offset, 12);

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -474,7 +474,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
         TokenResponseStatsCollector.ResponseStatus responseStatus = TokenResponseStatsCollector.ResponseStatus.Success;
 
         if (identityTokens.isEmptyToken()) {
-            response = ResponseUtil.SuccessNoBodyV2("optout");
+            response = ResponseUtil.SuccessNoBodyV2(ResponseStatus.OptOut);
             responseStatus = TokenResponseStatsCollector.ResponseStatus.OptOut;
         }
         else { //user not opted out and already generated valid identity token

--- a/src/test/java/com/uid2/operator/UIDOperatorServiceTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorServiceTest.java
@@ -196,7 +196,7 @@ public class UIDOperatorServiceTest {
     }
 
     @Test
-    public void testTestOptOutKey() {
+    public void testTestOptOutKey_DoNotRespectOptout() {
         final InputUtil.InputVal inputVal = InputUtil.normalizeEmail(IdentityConst.OptOutIdentityForEmail);
 
         final IdentityRequest identityRequest = new IdentityRequest(
@@ -208,9 +208,25 @@ public class UIDOperatorServiceTest {
         verify(shutdownHandler, atLeastOnce()).handleSaltRetrievalResponse(false);
         verify(shutdownHandler, never()).handleSaltRetrievalResponse(true);
         assertNotNull(tokens);
+        assertFalse(tokens.isEmptyToken());
 
         final RefreshToken refreshToken = this.tokenEncoder.decodeRefreshToken(tokens.getRefreshToken());
         assertEquals(RefreshResponse.Optout, uid2Service.refreshIdentity(refreshToken));
+    }
+
+    @Test
+    public void testTestOptOutKey_RespectOptout() {
+        final InputUtil.InputVal inputVal = InputUtil.normalizeEmail(IdentityConst.OptOutIdentityForEmail);
+
+        final IdentityRequest identityRequest = new IdentityRequest(
+                new PublisherIdentity(123, 124, 125),
+                inputVal.toUserIdentity(IdentityScope.UID2, 0, this.now),
+                OptoutCheckPolicy.RespectOptOut
+        );
+        final IdentityTokens tokens = uid2Service.generateIdentity(identityRequest);
+        assertTrue(tokens.isEmptyToken());
+        verify(shutdownHandler, atLeastOnce()).handleSaltRetrievalResponse(false);
+        verify(shutdownHandler, never()).handleSaltRetrievalResponse(true);
     }
 
     @Test

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -3992,7 +3992,6 @@ public class UIDOperatorVerticleTest {
                     assertEqualsClose(Instant.now().plusMillis(refreshExpiresAfter.toMillis()), Instant.ofEpochMilli(genBody.getLong("refresh_expires")), 10);
                     assertEqualsClose(Instant.now().plusMillis(refreshIdentityAfter.toMillis()), Instant.ofEpochMilli(genBody.getLong("refresh_from")), 10);
 
-                    assertFalse(optOutExpected);
                     assertTokenStatusMetrics(
                             clientSideTokenGenerateSiteId,
                             TokenResponseStatsCollector.Endpoint.ClientSideTokenGenerateV2,
@@ -4003,16 +4002,6 @@ public class UIDOperatorVerticleTest {
                     //test a subsequent refresh from this cstg call and see if it still works
                     sendTokenRefresh("v2", vertx, testContext, genRefreshToken, genBody.getString("refresh_response_key"), 200, refreshRespJson ->
                     {
-
-                        if (optOutExpected) {
-                            fail("Getting a successful optout response for an opted out user is impossible as the " +
-                                    "original CSTG request should already gave an optout response and no refresh " +
-                                    "token should be returned to make token refresh call and reach here!");
-                            return;
-                        }
-
-                        assertFalse(optOutExpected);
-
                         assertEquals("success", refreshRespJson.getString("status"));
                         JsonObject refreshBody = refreshRespJson.getJsonObject("body");
                         assertNotNull(refreshBody);

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -3139,14 +3139,12 @@ public class UIDOperatorVerticleTest {
 
     @ParameterizedTest
     @CsvSource({
-            "true,https://blahblah.com",
-            "false,https://blahblah.com",
-            "true,http://local1host:8080", //intentionally spelling localhost wrong here!
-            "false,http://local1host:8080",
+            "https://blahblah.com",
+            "http://local1host:8080", //intentionally spelling localhost wrong here!
     })
-    void cstgDomainNameCheckFails(boolean setOptoutCheckFlagInRequest, String httpOrigin, Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
+    void cstgDomainNameCheckFails(String httpOrigin, Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
         setupCstgBackend();
-        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli(), setOptoutCheckFlagInRequest);
+        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli());
         sendCstg(vertx,
                 "v2/token/client-generate",
                 httpOrigin,
@@ -3175,7 +3173,7 @@ public class UIDOperatorVerticleTest {
     })
     void cstgAppNameCheckFails(String appName, Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
         setupCstgBackend(Collections.emptyList(), List.of("com.123.Game.App.android"));
-        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli(), false, appName);
+        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli(), appName);
         sendCstg(vertx,
                 "v2/token/client-generate",
                 null,
@@ -3201,17 +3199,16 @@ public class UIDOperatorVerticleTest {
 
     @ParameterizedTest
     @CsvSource({
-            "true,http://gototest.com",
-            "false,http://gototest.com",
+            "http://gototest.com",
     })
-    void cstgDomainNameCheckFailsAndLogInvalidHttpOrigin(boolean setOptoutCheckFlagInRequest, String httpOrigin, Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
+    void cstgDomainNameCheckFailsAndLogInvalidHttpOrigin(String httpOrigin, Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
         ListAppender<ILoggingEvent> logWatcher = new ListAppender<>();
         logWatcher.start();
         ((Logger) LoggerFactory.getLogger(UIDOperatorVerticle.class)).addAppender(logWatcher);
         this.uidOperatorVerticle.setLastInvalidOriginProcessTime(Instant.now().minusSeconds(3600));
 
         setupCstgBackend();
-        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli(), setOptoutCheckFlagInRequest);
+        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli());
         sendCstg(vertx,
                 "v2/token/client-generate",
                 httpOrigin,
@@ -3242,7 +3239,7 @@ public class UIDOperatorVerticleTest {
         this.uidOperatorVerticle.setLastInvalidOriginProcessTime(Instant.now().minusSeconds(3600));
 
         setupCstgBackend();
-        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli(), false, appName);
+        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli(), appName);
         sendCstg(vertx,
                 "v2/token/client-generate",
                 null,
@@ -3288,7 +3285,7 @@ public class UIDOperatorVerticleTest {
         requestJson.put("timestamp", timestamp);
         requestJson.put("subscription_id", subscriptionID);
 
-        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli(), false, null);
+        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli(), null);
         sendCstg(vertx,
                 "v2/token/client-generate",
                 null,
@@ -3309,10 +3306,9 @@ public class UIDOperatorVerticleTest {
 
     @ParameterizedTest
     @CsvSource({
-            "true,http://gototest.com",
-            "false,http://gototest.com",
+            "http://gototest.com",
     })
-    void cstgDomainNameCheckFailsAndLogSeveralInvalidHttpOrigin(boolean setOptoutCheckFlagInRequest, String httpOrigin, Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
+    void cstgDomainNameCheckFailsAndLogSeveralInvalidHttpOrigin(String httpOrigin, Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
         ListAppender<ILoggingEvent> logWatcher = new ListAppender<>();
         logWatcher.start();
         ((Logger) LoggerFactory.getLogger(UIDOperatorVerticle.class)).addAppender(logWatcher);
@@ -3327,7 +3323,7 @@ public class UIDOperatorVerticleTest {
         setupCstgBackend();
         when(siteProvider.getSite(124)).thenReturn(new Site(124, "test2", true, new HashSet<>()));
 
-        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli(), setOptoutCheckFlagInRequest);
+        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli());
         sendCstg(vertx,
                 "v2/token/client-generate",
                 httpOrigin,
@@ -3351,16 +3347,13 @@ public class UIDOperatorVerticleTest {
 
     @ParameterizedTest
     @CsvSource({
-            "true,https://cstg.co.uk",
-            "false,https://cstg.co.uk",
-            "true,https://cstg2.com",
-            "false,https://cstg2.com",
-            "true,http://localhost:8080",
-            "false,http://localhost:8080",
+            "https://cstg.co.uk",
+            "https://cstg2.com",
+            "http://localhost:8080",
     })
-    void cstgDomainNameCheckPasses(boolean setOptoutCheckFlagInRequest, String httpOrigin, Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
+    void cstgDomainNameCheckPasses(String httpOrigin, Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
         setupCstgBackend("cstg.co.uk", "cstg2.com", "localhost");
-        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli(), setOptoutCheckFlagInRequest);
+        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli());
         sendCstg(vertx,
                 "v2/token/client-generate",
                 httpOrigin,
@@ -3387,7 +3380,7 @@ public class UIDOperatorVerticleTest {
     })
     void cstgAppNameCheckPasses(String appName, Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
         setupCstgBackend(Collections.emptyList(), List.of("com.123.Game.App.android", "123456789"));
-        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli(), false, appName);
+        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli(), appName);
         sendCstg(vertx,
                 "v2/token/client-generate",
                 null,
@@ -3868,11 +3861,11 @@ public class UIDOperatorVerticleTest {
         return new Tuple.Tuple2<>(requestJson, secretKey);
     }
 
-    private Tuple.Tuple2<JsonObject, SecretKey> createClientSideTokenGenerateRequest(IdentityType identityType, String rawId, long timestamp, boolean setOptoutCheckFlagInRequest) throws NoSuchAlgorithmException, InvalidKeyException {
-        return createClientSideTokenGenerateRequest(identityType, rawId, timestamp, setOptoutCheckFlagInRequest, null);
+    private Tuple.Tuple2<JsonObject, SecretKey> createClientSideTokenGenerateRequest(IdentityType identityType, String rawId, long timestamp) throws NoSuchAlgorithmException, InvalidKeyException {
+        return createClientSideTokenGenerateRequest(identityType, rawId, timestamp, null);
     }
 
-    private Tuple.Tuple2<JsonObject, SecretKey> createClientSideTokenGenerateRequest(IdentityType identityType, String rawId, long timestamp, boolean setOptoutCheckFlagInRequest, String appName) throws NoSuchAlgorithmException, InvalidKeyException {
+    private Tuple.Tuple2<JsonObject, SecretKey> createClientSideTokenGenerateRequest(IdentityType identityType, String rawId, long timestamp, String appName) throws NoSuchAlgorithmException, InvalidKeyException {
 
         JsonObject identity = new JsonObject();
 
@@ -3885,11 +3878,7 @@ public class UIDOperatorVerticleTest {
         else { //can't be other types
             assertFalse(true);
         }
-
-        if(setOptoutCheckFlagInRequest) {
-            identity.put("optout_check", 1);
-        }
-
+        
         return createClientSideTokenGenerateRequestWithPayload(identity, timestamp, appName);
     }
 
@@ -3901,15 +3890,13 @@ public class UIDOperatorVerticleTest {
 
     @ParameterizedTest
     @CsvSource({
-            "true,test@example.com,Email",
-            "true,+61400000000,Phone",
-            "false,test@example.com,Email",
-            "false,+61400000000,Phone",
+            "test@example.com,Email",
+            "+61400000000,Phone"
     })
-    void cstgUserOptsOutAfterTokenGenerate(boolean setOptoutCheckFlagInRequest, String id, IdentityType identityType, Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
+    void cstgUserOptsOutAfterTokenGenerate(String id, IdentityType identityType, Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
         setupCstgBackend("cstg.co.uk");
 
-        final Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(identityType, id, Instant.now().toEpochMilli(), setOptoutCheckFlagInRequest);
+        final Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(identityType, id, Instant.now().toEpochMilli());
 
         // When we generate the token the user hasn't opted out.
         when(optOutStore.getLatestEntry(any(UserIdentity.class)))
@@ -3935,60 +3922,34 @@ public class UIDOperatorVerticleTest {
                     final AdvertisingToken advertisingToken = validateAndGetToken(encoder, genBody, identityType);
                     final RefreshToken refreshToken = decodeRefreshToken(encoder, decodeV2RefreshToken(response), identityType);
 
-                    assertAreClientSideGeneratedTokens(advertisingToken, refreshToken, clientSideTokenGenerateSiteId, identityType, id, setOptoutCheckFlagInRequest);
+                    assertAreClientSideGeneratedTokens(advertisingToken, refreshToken, clientSideTokenGenerateSiteId, identityType, id);
 
                     // When we refresh the token the user has opted out.
                     when(optOutStore.getLatestEntry(any(UserIdentity.class)))
                         .thenReturn(advertisingToken.userIdentity.establishedAt.plusSeconds(1));
 
                     sendTokenRefresh("v2", vertx, testContext, genBody.getString("refresh_token"), genBody.getString("refresh_response_key"), 200, refreshRespJson -> {
-
-                        if (setOptoutCheckFlagInRequest || getIdentityScope() == IdentityScope.EUID) {
-                            assertEquals("optout", refreshRespJson.getString("status"));
-                            testContext.completeNow();
-                            return;
-                        }
-
-                        // EUID can't have an opt out token ever
-                        assertEquals(getIdentityScope(), IdentityScope.UID2);
-
-                        verify(optOutStore, times(2)).getLatestEntry(argumentCaptor.capture());
-                        assertArrayEquals(TokenUtils.getFirstLevelHashFromIdentity(id, firstLevelSalt), argumentCaptor.getValue().id);
-
-                        assertEquals("success", refreshRespJson.getString("status"));
-                        final JsonObject refreshBody = refreshRespJson.getJsonObject("body");
-
-                        final AdvertisingToken adTokenFromRefresh = validateAndGetToken(encoder, refreshBody, identityType);
-                        final RefreshToken refreshTokenFromRefresh = decodeRefreshToken(encoder, decodeV2RefreshToken(refreshRespJson), identityType);
-
-                        assertAreClientSideGeneratedOptOutTokens(adTokenFromRefresh, refreshTokenFromRefresh, clientSideTokenGenerateSiteId, identityType, setOptoutCheckFlagInRequest);
-
-                        verifyNoMoreInteractions(optOutStore);
-
+                        assertEquals("optout", refreshRespJson.getString("status"));
                         testContext.completeNow();
                     });
                 });
     }
 
-    // tests for opted out user should lead to generating ad tokens with the default optout identity or optout success response depends on setOptoutCheckFlagInRequest flag
+    // tests for opted out user should lead to generating ad tokens with optout success response
     // tests for opted in user should lead to generating ad tokens that never match the default optout identity
     // tests for all email/phone combos
     @ParameterizedTest
     @CsvSource({
-            "true,true,abc@abc.com,Email,optout@unifiedid.com",
-            "true,true,+61400000000,Phone,+00000000001",
-            "true,false,abc@abc.com,Email,optout@unifiedid.com",
-            "true,false,+61400000000,Phone,+00000000001",
-            "false,true,abc@abc.com,Email,optout@unifiedid.com",
-            "false,true,+61400000000,Phone,+00000000001",
-            "false,false,abc@abc.com,Email,optout@unifiedid.com",
-            "false,false,+61400000000,Phone,+00000000001"
+            "true,abc@abc.com,Email,optout@unifiedid.com",
+            "true,+61400000000,Phone,+00000000001",
+            "false,abc@abc.com,Email,optout@unifiedid.com",
+            "false,+61400000000,Phone,+00000000001",
     })
-    void cstgOptedOutTest(boolean setOptoutCheckFlagInRequest, boolean optOutExpected, String id, IdentityType identityType, String expectedOptedOutIdentity,
+    void cstgOptedOutTest(boolean optOutExpected, String id, IdentityType identityType, String expectedOptedOutIdentity,
                           Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
         setupCstgBackend("cstg.co.uk");
 
-        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(identityType, id, Instant.now().toEpochMilli(), setOptoutCheckFlagInRequest);
+        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(identityType, id, Instant.now().toEpochMilli());
 
         if(optOutExpected)
         {
@@ -4009,8 +3970,7 @@ public class UIDOperatorVerticleTest {
                 testContext,
                 respJson -> {
 
-                    if (optOutExpected
-                            && (setOptoutCheckFlagInRequest || getIdentityScope() == IdentityScope.EUID)) {
+                    if (optOutExpected) {
                         assertEquals("optout", respJson.getString("status"));
                         testContext.completeNow();
                         return;
@@ -4027,9 +3987,9 @@ public class UIDOperatorVerticleTest {
                     RefreshToken refreshToken = decodeRefreshToken(encoder, genBody.getString("decrypted_refresh_token"), identityType);
 
                     if (optOutExpected) {
-                        assertAreClientSideGeneratedOptOutTokens(advertisingToken, refreshToken, clientSideTokenGenerateSiteId, identityType, setOptoutCheckFlagInRequest);
+                        assertAreClientSideGeneratedOptOutTokens(advertisingToken, refreshToken, clientSideTokenGenerateSiteId, identityType);
                     } else {
-                        assertAreClientSideGeneratedTokens(advertisingToken, refreshToken, clientSideTokenGenerateSiteId, identityType, id, setOptoutCheckFlagInRequest);
+                        assertAreClientSideGeneratedTokens(advertisingToken, refreshToken, clientSideTokenGenerateSiteId, identityType, id);
                     }
 
                     assertEqualsClose(Instant.now().plusMillis(identityExpiresAfter.toMillis()), Instant.ofEpochMilli(genBody.getLong("identity_expires")), 10);
@@ -4065,16 +4025,12 @@ public class UIDOperatorVerticleTest {
                     sendTokenRefresh("v2", vertx, testContext, genRefreshToken, genBody.getString("refresh_response_key"), 200, refreshRespJson ->
                     {
 
-                        if (optOutExpected
-                                && (setOptoutCheckFlagInRequest || getIdentityScope() == IdentityScope.EUID)) {
+                        if (optOutExpected) {
                             fail("Getting a successful optout response for an opted out user with optout check is impossible as the original CSTG request should already gave an optout response and no refresh token should be returned to reach here!");
                             return;
                         }
 
-                        // EUID can't have an opt out token - the only way is when optout isn't expected
-                        if(getIdentityScope() == IdentityScope.EUID) {
-                            assert(!optOutExpected);
-                        }
+                        assert(!optOutExpected);
 
                         assertEquals("success", refreshRespJson.getString("status"));
                         JsonObject refreshBody = refreshRespJson.getJsonObject("body");
@@ -4089,9 +4045,9 @@ public class UIDOperatorVerticleTest {
                         RefreshToken refreshTokenAfterRefresh = decodeRefreshToken(encoder, refreshTokenStringNew, identityType);
 
                         if (optOutExpected) {
-                            assertAreClientSideGeneratedOptOutTokens(adTokenFromRefresh, refreshTokenAfterRefresh, clientSideTokenGenerateSiteId, identityType, setOptoutCheckFlagInRequest);
+                            assertAreClientSideGeneratedOptOutTokens(adTokenFromRefresh, refreshTokenAfterRefresh, clientSideTokenGenerateSiteId, identityType);
                         } else {
-                            assertAreClientSideGeneratedTokens(adTokenFromRefresh, refreshTokenAfterRefresh, clientSideTokenGenerateSiteId, identityType, id, setOptoutCheckFlagInRequest);
+                            assertAreClientSideGeneratedTokens(adTokenFromRefresh, refreshTokenAfterRefresh, clientSideTokenGenerateSiteId, identityType, id);
                         }
 
                         assertEqualsClose(Instant.now().plusMillis(identityExpiresAfter.toMillis()), Instant.ofEpochMilli(refreshBody.getLong("identity_expires")), 10);
@@ -4111,17 +4067,14 @@ public class UIDOperatorVerticleTest {
 
     @ParameterizedTest
     @CsvSource({
-            "true,https://cstg.co.uk",
-            "false,https://cstg.co.uk",
-            "true,https://cstg2.com",
-            "false,https://cstg2.com",
-            "true,http://localhost:8080",
-            "false,http://localhost:8080",
+            "https://cstg.co.uk",
+            "https://cstg2.com",
+            "http://localhost:8080",
     })
-    void cstgSaltsExpired(boolean setOptoutCheckFlagInRequest, String httpOrigin, Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
+    void cstgSaltsExpired(String httpOrigin, Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
         when(saltProviderSnapshot.getExpires()).thenReturn(Instant.now().minus(1, ChronoUnit.HOURS));
         setupCstgBackend("cstg.co.uk", "cstg2.com", "localhost");
-        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli(), setOptoutCheckFlagInRequest);
+        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli());
         sendCstg(vertx,
                 "v2/token/client-generate",
                 httpOrigin,
@@ -4147,7 +4100,7 @@ public class UIDOperatorVerticleTest {
     void cstgNoActiveKey(Vertx vertx, VertxTestContext testContext) throws NoSuchAlgorithmException, InvalidKeyException {
         setupCstgBackend("cstg.co.uk");
         setupKeys(true);
-        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli(), true);
+        Tuple.Tuple2<JsonObject, SecretKey> data = createClientSideTokenGenerateRequest(IdentityType.Email, "random@unifiedid.com", Instant.now().toEpochMilli());
         sendCstg(vertx,
                 "v2/token/client-generate",
                 "http://cstg.co.uk",
@@ -4190,18 +4143,16 @@ public class UIDOperatorVerticleTest {
                 });
     }
 
-    private void assertAreClientSideGeneratedTokens(AdvertisingToken advertisingToken, RefreshToken refreshToken, int siteId, IdentityType identityType, String identity,
-                                                    boolean expectClientSideTokenGenerateOptoutResponse) {
+    private void assertAreClientSideGeneratedTokens(AdvertisingToken advertisingToken, RefreshToken refreshToken, int siteId, IdentityType identityType, String identity) {
         assertAreClientSideGeneratedTokens(advertisingToken,
                 refreshToken,
                 siteId,
                 identityType,
                 identity,
-                false,
-                expectClientSideTokenGenerateOptoutResponse);
+                false);
     }
 
-    private void assertAreClientSideGeneratedOptOutTokens(AdvertisingToken advertisingToken, RefreshToken refreshToken, int siteId, IdentityType identityType, boolean expectClientSideTokenGenerateOptoutResponse) {
+    private void assertAreClientSideGeneratedOptOutTokens(AdvertisingToken advertisingToken, RefreshToken refreshToken, int siteId, IdentityType identityType) {
         final String identity = getClientSideGeneratedTokenOptOutIdentity(identityType);
 
         assertAreClientSideGeneratedTokens(advertisingToken,
@@ -4209,12 +4160,10 @@ public class UIDOperatorVerticleTest {
                 siteId,
                 identityType,
                 identity,
-                true,
-                expectClientSideTokenGenerateOptoutResponse);
+                true);
     }
 
-    private void assertAreClientSideGeneratedTokens(AdvertisingToken advertisingToken, RefreshToken refreshToken, int siteId, IdentityType identityType, String identity, boolean expectedOptOut,
-                                                    boolean expectClientSideTokenGenerateOptoutResponse) {
+    private void assertAreClientSideGeneratedTokens(AdvertisingToken advertisingToken, RefreshToken refreshToken, int siteId, IdentityType identityType, String identity, boolean expectedOptOut) {
         final PrivacyBits advertisingTokenPrivacyBits = PrivacyBits.fromInt(advertisingToken.userIdentity.privacyBits);
         final PrivacyBits refreshTokenPrivacyBits = PrivacyBits.fromInt(refreshToken.userIdentity.privacyBits);
 
@@ -4226,9 +4175,6 @@ public class UIDOperatorVerticleTest {
         final byte[] firstLevelHash = TokenUtils.getFirstLevelHashFromIdentity(identity, firstLevelSalt);
 
         assertAll(
-                () -> assertEquals(advertisingTokenPrivacyBits.isClientSideTokenGenerateOptoutResponseOn(), expectClientSideTokenGenerateOptoutResponse, "Advertising token privacy bits CSTG Optout Response flag is incorrect"),
-                () -> assertEquals(refreshTokenPrivacyBits.isClientSideTokenGenerateOptoutResponseOn(), expectClientSideTokenGenerateOptoutResponse, "Refresh token privacy bits CSTG Optout Response flag is incorrect"),
-
                 () -> assertTrue(advertisingTokenPrivacyBits.isClientSideTokenGenerated(), "Advertising token privacy bits CSTG flag is incorrect"),
                 () -> assertEquals(expectedOptOut, advertisingTokenPrivacyBits.isClientSideTokenOptedOut(), "Advertising token privacy bits CSTG optout flag is incorrect"),
 

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -3986,12 +3986,7 @@ public class UIDOperatorVerticleTest {
 
                     RefreshToken refreshToken = decodeRefreshToken(encoder, genBody.getString("decrypted_refresh_token"), identityType);
 
-                    if (optOutExpected) {
-                        assertAreClientSideGeneratedOptOutTokens(advertisingToken, refreshToken, clientSideTokenGenerateSiteId, identityType);
-                    } else {
-                        assertAreClientSideGeneratedTokens(advertisingToken, refreshToken, clientSideTokenGenerateSiteId, identityType, id);
-                    }
-
+                    assertAreClientSideGeneratedTokens(advertisingToken, refreshToken, clientSideTokenGenerateSiteId, identityType, id);
                     assertEqualsClose(Instant.now().plusMillis(identityExpiresAfter.toMillis()), Instant.ofEpochMilli(genBody.getLong("identity_expires")), 10);
                     assertEqualsClose(Instant.now().plusMillis(refreshExpiresAfter.toMillis()), Instant.ofEpochMilli(genBody.getLong("refresh_expires")), 10);
                     assertEqualsClose(Instant.now().plusMillis(refreshIdentityAfter.toMillis()), Instant.ofEpochMilli(genBody.getLong("refresh_from")), 10);
@@ -4044,12 +4039,7 @@ public class UIDOperatorVerticleTest {
                         assertNotEquals(genRefreshToken, refreshTokenStringNew);
                         RefreshToken refreshTokenAfterRefresh = decodeRefreshToken(encoder, refreshTokenStringNew, identityType);
 
-                        if (optOutExpected) {
-                            assertAreClientSideGeneratedOptOutTokens(adTokenFromRefresh, refreshTokenAfterRefresh, clientSideTokenGenerateSiteId, identityType);
-                        } else {
-                            assertAreClientSideGeneratedTokens(adTokenFromRefresh, refreshTokenAfterRefresh, clientSideTokenGenerateSiteId, identityType, id);
-                        }
-
+                        assertAreClientSideGeneratedTokens(adTokenFromRefresh, refreshTokenAfterRefresh, clientSideTokenGenerateSiteId, identityType, id);
                         assertEqualsClose(Instant.now().plusMillis(identityExpiresAfter.toMillis()), Instant.ofEpochMilli(refreshBody.getLong("identity_expires")), 10);
                         assertEqualsClose(Instant.now().plusMillis(refreshExpiresAfter.toMillis()), Instant.ofEpochMilli(refreshBody.getLong("refresh_expires")), 10);
                         assertEqualsClose(Instant.now().plusMillis(refreshIdentityAfter.toMillis()), Instant.ofEpochMilli(refreshBody.getLong("refresh_from")), 10);


### PR DESCRIPTION
Changes:

1. Modify the changes in https://github.com/IABTechLab/uid2-operator/pull/343/files for UID2 environment to remove the option of setting optout_check flag in CSTG request 
2. always return optout response for opted out users in UID2 CSTG endpoint (EUID already had this since beginning of this year)
3. always return optout response for opted out users in UID2 token/refresh calls from CSTG derived tokens (EUID already had this since beginning of this year)
4. Simplify unit tests to no longer have the option to expect optout token/optout response for CSTG endpoints and the resulting CSTG token refreshes