### PR TITLE
Refactor enclave entrypoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.40.22</version>
+    <version>5.40.23-alpha-13-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.40.24-alpha-14-SNAPSHOT</version>
+    <version>5.40.25-alpha-15-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/scripts/aws/entrypoint.sh
+++ b/scripts/aws/entrypoint.sh
@@ -29,9 +29,16 @@ echo "Loading config from identity service via proxy..."
 #wait for config service, then download config
 OVERRIDES_CONFIG="/app/conf/config-overrides.json"
 
+RETRY_COUNT=0
+MAX_RETRY=20
 until curl -s -f -o "${OVERRIDES_CONFIG}" -x socks5h://127.0.0.1:3305 http://127.0.0.1:27015/getConfig
 do
   echo "Waiting for config service to be available"
+  RETRY_COUNT=$(( RETRY_COUNT + 1))
+  if [ $RETRY_COUNT -gt $MAX_RETRY ]; then
+      echo "Config Server did not return a response. Exiting"
+      exit 1
+  fi
   sleep 2
 done
 

--- a/scripts/aws/entrypoint.sh
+++ b/scripts/aws/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -eufx
+
+# This is the entrypoint for the Enclave. It is executed in all enclaves - EC2 and EKS
+
 LOG_FILE="/home/start.txt"
 
 set -x
@@ -22,38 +25,23 @@ echo "Starting syslog-ng..."
 
 # -- load config from identity service
 echo "Loading config from identity service via proxy..."
-set +e
-#wait for config service
-RETRY_COUNT=0
-MAX_RETRY=10
-while true; do
-  RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -x socks5h://127.0.0.1:3305 http://127.0.0.1:27015/getConfig)
-  if [ "$RESPONSE" -eq "200" ]; then
-      echo "Config server running"
-      break;
-  else
-      echo "Config server still starting..."
-  fi
-  RETRY_COUNT=$(( RETRY_COUNT + 1))
-  if [ $RETRY_COUNT -gt $MAX_RETRY ]; then
-      echo "Config Server did not return a response. Exiting"
-      exit 1
-  fi
-  sleep 5
 
+#wait for config service, then download config
+export OVERRIDES_CONFIG="/app/conf/config-overrides.json"
+
+until curl -s -f -o "${OVERRIDES_CONFIG}" -x "socks5h://127.0.0.1:3305 http://127.0.0.1:27015/getConfig"
+do
+  echo "Waiting for config service to be available"
+  sleep 2
 done
 
-{ set +x; } 2>/dev/null; { IDENTITY_SERVICE_CONFIG=$(curl -s -x socks5h://127.0.0.1:3305 http://127.0.0.1:27015/getConfig); set -x; }
-if jq -e . >/dev/null 2>&1 <<<"${IDENTITY_SERVICE_CONFIG}"; then
+# check the config is valid. Querying for a known missing element (empty) makes jq parse the file, but does not echo the results
+if jq empty "${OVERRIDES_CONFIG}"; then
     echo "Identity service returned valid config"
 else
     echo "Failed to get a valid config from identity service"
     exit 1
 fi
-set -e
-
-export OVERRIDES_CONFIG="/app/conf/config-overrides.json"
-{ set +x; } 2>/dev/null; { echo "${IDENTITY_SERVICE_CONFIG}" > "${OVERRIDES_CONFIG}"; set -x; }
 
 export DEPLOYMENT_ENVIRONMENT=$(jq -r ".environment" < "${OVERRIDES_CONFIG}")
 export CORE_BASE_URL=$(jq -r ".core_base_url" < "${OVERRIDES_CONFIG}")

--- a/scripts/aws/entrypoint.sh
+++ b/scripts/aws/entrypoint.sh
@@ -29,7 +29,7 @@ echo "Loading config from identity service via proxy..."
 #wait for config service, then download config
 export OVERRIDES_CONFIG="/app/conf/config-overrides.json"
 
-until curl -s -f -o "${OVERRIDES_CONFIG}" -x "socks5h://127.0.0.1:3305 http://127.0.0.1:27015/getConfig"
+until curl -s -f -o "${OVERRIDES_CONFIG}" -x socks5h://127.0.0.1:3305 http://127.0.0.1:27015/getConfig
 do
   echo "Waiting for config service to be available"
   sleep 2

--- a/scripts/aws/entrypoint.sh
+++ b/scripts/aws/entrypoint.sh
@@ -27,7 +27,7 @@ echo "Starting syslog-ng..."
 echo "Loading config from identity service via proxy..."
 
 #wait for config service, then download config
-export OVERRIDES_CONFIG="/app/conf/config-overrides.json"
+OVERRIDES_CONFIG="/app/conf/config-overrides.json"
 
 until curl -s -f -o "${OVERRIDES_CONFIG}" -x socks5h://127.0.0.1:3305 http://127.0.0.1:27015/getConfig
 do


### PR DESCRIPTION
Refactored the entrypoint to remove the duplicate call to getConfig
Tested in Test and operator starts correctly. Checked the logs, and the configuration is not echoed to the logs, as expected. 