### PR TITLE
Only shut the operator down when receiving an AttestationFailure response from Core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.40.87-alpha-108-SNAPSHOT</version>
+    <version>5.40.88-alpha-109-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.40.86</version>
+    <version>5.40.87-alpha-108-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <enclave-aws.version>2.1.0</enclave-aws.version>
         <enclave-azure.version>2.1.0</enclave-azure.version>
         <enclave-gcp.version>2.1.0</enclave-gcp.version>
-        <uid2-shared.version>7.19.1-SNAPSHOT</uid2-shared.version>
+        <uid2-shared.version>7.19.2-alpha-151-SNAPSHOT</uid2-shared.version>
         <image.version>${project.version}</image.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <enclave-aws.version>2.1.0</enclave-aws.version>
         <enclave-azure.version>2.1.0</enclave-azure.version>
         <enclave-gcp.version>2.1.0</enclave-gcp.version>
-        <uid2-shared.version>7.19.0</uid2-shared.version>
+        <uid2-shared.version>7.19.1-SNAPSHOT</uid2-shared.version>
         <image.version>${project.version}</image.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <enclave-aws.version>2.1.0</enclave-aws.version>
         <enclave-azure.version>2.1.0</enclave-azure.version>
         <enclave-gcp.version>2.1.0</enclave-gcp.version>
-        <uid2-shared.version>7.19.2-alpha-151-SNAPSHOT</uid2-shared.version>
+        <uid2-shared.version>7.20.0</uid2-shared.version>
         <image.version>${project.version}</image.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/src/main/java/com/uid2/operator/Main.java
+++ b/src/main/java/com/uid2/operator/Main.java
@@ -467,14 +467,14 @@ public class Main {
                 .register(globalRegistry);
     }
 
-    private Map.Entry<UidCoreClient, UidOptOutClient> createUidClients(Vertx vertx, String attestationUrl, String clientApiToken, Handler<Pair<Integer, String>> responseWatcher) throws Exception {
+    private Map.Entry<UidCoreClient, UidOptOutClient> createUidClients(Vertx vertx, String attestationUrl, String clientApiToken, Handler<Pair<AttestationResponseCode, String>> responseWatcher) throws Exception {
         AttestationResponseHandler attestationResponseHandler = getAttestationTokenRetriever(vertx, attestationUrl, clientApiToken, responseWatcher);
         UidCoreClient coreClient = new UidCoreClient(clientApiToken, CloudUtils.defaultProxy, attestationResponseHandler);
         UidOptOutClient optOutClient = new UidOptOutClient(clientApiToken, CloudUtils.defaultProxy, attestationResponseHandler);
         return new AbstractMap.SimpleEntry<>(coreClient, optOutClient);
     }
 
-    private AttestationResponseHandler getAttestationTokenRetriever(Vertx vertx, String attestationUrl, String clientApiToken, Handler<Pair<Integer, String>> responseWatcher) throws Exception {
+    private AttestationResponseHandler getAttestationTokenRetriever(Vertx vertx, String attestationUrl, String clientApiToken, Handler<Pair<AttestationResponseCode, String>> responseWatcher) throws Exception {
         String enclavePlatform = this.config.getString(Const.Config.EnclavePlatformProp);
         String operatorType = this.config.getString(Const.Config.OperatorTypeProp, "");
 

--- a/src/main/java/com/uid2/operator/vertx/OperatorShutdownHandler.java
+++ b/src/main/java/com/uid2/operator/vertx/OperatorShutdownHandler.java
@@ -1,6 +1,8 @@
 package com.uid2.operator.vertx;
 
 import com.uid2.operator.service.ShutdownService;
+import com.uid2.shared.attest.AttestationResponseCode;
+import lombok.extern.java.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.utils.Pair;
@@ -52,12 +54,12 @@ public class OperatorShutdownHandler {
         }
     }
 
-    public void handleAttestResponse(Pair<Integer, String> response) {
-        if (response.left() == 401) {
-            LOGGER.error("core attestation failed with 401, shutting down operator, core response: " + response.right());
+    public void handleAttestResponse(Pair<AttestationResponseCode, String> response) {
+        if (response.left() == AttestationResponseCode.AttestationFailure) {
+            LOGGER.error("core attestation failed with AttestationFailure, shutting down operator, core response: {}", response.right());
             this.shutdownService.Shutdown(1);
         }
-        if (response.left() == 200) {
+        if (response.left() == AttestationResponseCode.Success) {
             attestFailureStartTime.set(null);
         } else {
             Instant t = attestFailureStartTime.get();


### PR DESCRIPTION
Tested with branch deploy. Ran in Integ and passed validation. 