### PR TITLE
1. 

### DIFF
--- a/src/main/java/com/uid2/operator/model/AdvertisingTokenInput.java
+++ b/src/main/java/com/uid2/operator/model/AdvertisingTokenInput.java
@@ -10,12 +10,18 @@ public class AdvertisingTokenInput extends VersionedToken {
     public final SourcePublisher sourcePublisher;
     public final RawUidIdentity rawUidIdentity;
 
+    public final int privacyBits;
+    public final Instant establishedAt;
+
     public AdvertisingTokenInput(TokenVersion version, Instant createdAt, Instant expiresAt, OperatorIdentity operatorIdentity,
-                                 SourcePublisher sourcePublisher, RawUidIdentity rawUidIdentity) {
+                                 SourcePublisher sourcePublisher, RawUidIdentity rawUidIdentity, int privacyBits,
+                                 Instant establishedAt) {
         super(version, createdAt, expiresAt);
         this.operatorIdentity = operatorIdentity;
         this.sourcePublisher = sourcePublisher;
         this.rawUidIdentity = rawUidIdentity;
+        this.privacyBits = privacyBits;
+        this.establishedAt = establishedAt;
     }
 }
 

--- a/src/main/java/com/uid2/operator/model/IdentityRequest.java
+++ b/src/main/java/com/uid2/operator/model/IdentityRequest.java
@@ -2,19 +2,28 @@ package com.uid2.operator.model;
 
 import com.uid2.operator.model.userIdentity.HashedDiiIdentity;
 
+import java.time.Instant;
+
 public final class IdentityRequest {
     public final SourcePublisher sourcePublisher;
     public final HashedDiiIdentity hashedDiiIdentity;
     public final OptoutCheckPolicy optoutCheckPolicy;
 
+    public final int privacyBits;
+    public final Instant establishedAt;
+
     public IdentityRequest(
             SourcePublisher sourcePublisher,
             HashedDiiIdentity hashedDiiIdentity,
-            OptoutCheckPolicy tokenGeneratePolicy)
+            OptoutCheckPolicy tokenGeneratePolicy,
+            int privacyBits,
+            Instant establishedAt)
     {
         this.sourcePublisher = sourcePublisher;
         this.hashedDiiIdentity = hashedDiiIdentity;
         this.optoutCheckPolicy = tokenGeneratePolicy;
+        this.privacyBits = privacyBits;
+        this.establishedAt = establishedAt;
     }
 
     public boolean shouldCheckOptOut() {

--- a/src/main/java/com/uid2/operator/model/userIdentity/FirstLevelHashIdentity.java
+++ b/src/main/java/com/uid2/operator/model/userIdentity/FirstLevelHashIdentity.java
@@ -10,10 +10,20 @@ import java.util.Arrays;
 public class FirstLevelHashIdentity extends UserIdentity {
     public final byte[] firstLevelHash;
 
+    // for brand new token generation, it should contain 1
+    // if the first level hash is from token/refresh call, it will inherit from the refresh token
+    public final int privacyBits;
+
+    // for brand new token generation, it should be the time it is generated
+    // if the first level hash is from token/refresh call, it will be when the raw UID was originally created in the earliest token generation
+    public final Instant establishedAt;
+
     public FirstLevelHashIdentity(IdentityScope identityScope, IdentityType identityType, byte[] firstLevelHash, int privacyBits,
                                   Instant establishedAt) {
-        super(identityScope, identityType, privacyBits, establishedAt);
+        super(identityScope, identityType);
         this.firstLevelHash = firstLevelHash;
+        this.privacyBits = privacyBits;
+        this.establishedAt = establishedAt;
     }
 
     public boolean matches(FirstLevelHashIdentity that) {

--- a/src/main/java/com/uid2/operator/model/userIdentity/HashedDiiIdentity.java
+++ b/src/main/java/com/uid2/operator/model/userIdentity/HashedDiiIdentity.java
@@ -10,9 +10,8 @@ import java.time.Instant;
 public class HashedDiiIdentity extends UserIdentity {
     public final byte[] hashedDii;
 
-    public HashedDiiIdentity(IdentityScope identityScope, IdentityType identityType, byte[] hashedDii, int privacyBits,
-                             Instant establishedAt) {
-        super(identityScope, identityType, privacyBits, establishedAt);
+    public HashedDiiIdentity(IdentityScope identityScope, IdentityType identityType, byte[] hashedDii) {
+        super(identityScope, identityType);
         this.hashedDii = hashedDii;
     }
 }

--- a/src/main/java/com/uid2/operator/model/userIdentity/RawUidIdentity.java
+++ b/src/main/java/com/uid2/operator/model/userIdentity/RawUidIdentity.java
@@ -10,9 +10,8 @@ import java.util.Arrays;
 public class RawUidIdentity extends UserIdentity {
     public final byte[] rawUid;
 
-    public RawUidIdentity(IdentityScope identityScope, IdentityType identityType, byte[] rawUid, int privacyBits,
-                          Instant establishedAt) {
-        super(identityScope, identityType, privacyBits, establishedAt);
+    public RawUidIdentity(IdentityScope identityScope, IdentityType identityType, byte[] rawUid) {
+        super(identityScope, identityType);
         this.rawUid = rawUid;
     }
 

--- a/src/main/java/com/uid2/operator/model/userIdentity/UserIdentity.java
+++ b/src/main/java/com/uid2/operator/model/userIdentity/UserIdentity.java
@@ -10,13 +10,9 @@ public abstract class UserIdentity {
 
     public final IdentityScope identityScope;
     public final IdentityType identityType;
-    public final int privacyBits;
-    public final Instant establishedAt;
 
-    public UserIdentity(IdentityScope identityScope, IdentityType identityType, int privacyBits, Instant establishedAt) {
+    public UserIdentity(IdentityScope identityScope, IdentityType identityType) {
         this.identityScope = identityScope;
         this.identityType = identityType;
-        this.privacyBits = privacyBits;
-        this.establishedAt = establishedAt;
     }
 }

--- a/src/main/java/com/uid2/operator/service/InputUtil.java
+++ b/src/main/java/com/uid2/operator/service/InputUtil.java
@@ -261,13 +261,11 @@ public class InputUtil {
             return valid;
         }
 
-        public HashedDiiIdentity toHashedDiiIdentity(IdentityScope identityScope, int privacyBits, Instant establishedAt) {
+        public HashedDiiIdentity toHashedDiiIdentity(IdentityScope identityScope) {
             return new HashedDiiIdentity(
                     identityScope,
                     this.identityType,
-                    getIdentityInput(),
-                    privacyBits,
-                    establishedAt);
+                    getIdentityInput());
         }
     }
 

--- a/src/test/java/com/uid2/operator/TokenEncodingTest.java
+++ b/src/test/java/com/uid2/operator/TokenEncodingTest.java
@@ -101,7 +101,9 @@ public class TokenEncodingTest {
             now.plusSeconds(60),
             new OperatorIdentity(101, OperatorType.Service, 102, 103),
             new SourcePublisher(111, 112, 113),
-            new RawUidIdentity(IdentityScope.UID2, IdentityType.Email, rawUid, 121, now)
+            new RawUidIdentity(IdentityScope.UID2, IdentityType.Email, rawUid),
+            121,
+            now
         );
 
         final byte[] encodedBytes = encoder.encodeIntoAdvertisingToken(adTokenInput, now);
@@ -111,8 +113,8 @@ public class TokenEncodingTest {
         assertEquals(adTokenInput.createdAt, decoded.createdAt);
         assertEquals(adTokenInput.expiresAt, decoded.expiresAt);
         assertTrue(adTokenInput.rawUidIdentity.matches(decoded.rawUidIdentity));
-        assertEquals(adTokenInput.rawUidIdentity.privacyBits, decoded.rawUidIdentity.privacyBits);
-        assertEquals(adTokenInput.rawUidIdentity.establishedAt, decoded.rawUidIdentity.establishedAt);
+        assertEquals(adTokenInput.privacyBits, decoded.privacyBits);
+        assertEquals(adTokenInput.establishedAt, decoded.establishedAt);
         assertEquals(adTokenInput.sourcePublisher.siteId, decoded.sourcePublisher.siteId);
 
         Buffer b = Buffer.buffer(encodedBytes);

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -1180,10 +1180,10 @@ public class UIDOperatorVerticleTest {
                     String advertisingTokenString = body.getString("advertising_token");
                     final Instant now = Instant.now();
                     final String token = advertisingTokenString;
-                    final boolean matchedOptedOutIdentity = this.uidOperatorVerticle.getIdService().advertisingTokenMatches(token, optOutTokenInput.toHashedDiiIdentity(getIdentityScope(), 0, now), now);
+                    final boolean matchedOptedOutIdentity = this.uidOperatorVerticle.getIdService().advertisingTokenMatches(token, optOutTokenInput.toHashedDiiIdentity(getIdentityScope()), now);
                     assertTrue(matchedOptedOutIdentity);
-                    assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenGenerated());
-                    assertTrue(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenOptedOut());
+                    assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenGenerated());
+                    assertTrue(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenOptedOut());
 
                     assertTokenStatusMetrics(
                             201,
@@ -1229,8 +1229,8 @@ public class UIDOperatorVerticleTest {
 
                     AdvertisingTokenInput advertisingTokenInput = validateAndGetToken(encoder, body, IdentityType.Email);
 
-                    assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenGenerated());
-                    assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenOptedOut());
+                    assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenGenerated());
+                    assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenOptedOut());
                     assertEquals(clientSiteId, advertisingTokenInput.sourcePublisher.siteId);
                     assertArrayEquals(getRawUidFromIdentity(IdentityType.Email, emailAddress, firstLevelSalt, rotatingSalt123.getSalt()), advertisingTokenInput.rawUidIdentity.rawUid);
 
@@ -1271,8 +1271,8 @@ public class UIDOperatorVerticleTest {
 
                     AdvertisingTokenInput advertisingTokenInput = validateAndGetToken(encoder, body, IdentityType.Email);
 
-                    assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenGenerated());
-                    assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenOptedOut());
+                    assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenGenerated());
+                    assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenOptedOut());
                     assertEquals(clientSiteId, advertisingTokenInput.sourcePublisher.siteId);
                     assertArrayEquals(getRawUidFromIdentityHash(IdentityType.Email, emailHash, firstLevelSalt, rotatingSalt123.getSalt()), advertisingTokenInput.rawUidIdentity.rawUid);
 
@@ -1315,8 +1315,8 @@ public class UIDOperatorVerticleTest {
 
                 AdvertisingTokenInput advertisingTokenInput = validateAndGetToken(encoder, refreshBody, IdentityType.Email);
 
-                assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenGenerated());
-                assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenOptedOut());
+                assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenGenerated());
+                assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenOptedOut());
                 assertEquals(clientSiteId, advertisingTokenInput.sourcePublisher.siteId);
                 assertArrayEquals(getRawUidFromIdentity(IdentityType.Email, emailAddress, firstLevelSalt, rotatingSalt123.getSalt()), advertisingTokenInput.rawUidIdentity.rawUid);
 
@@ -1374,8 +1374,8 @@ public class UIDOperatorVerticleTest {
 
                 AdvertisingTokenInput advertisingTokenInput = validateAndGetToken(encoder, refreshBody, IdentityType.Email);
 
-                assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenGenerated());
-                assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenOptedOut());
+                assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenGenerated());
+                assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenOptedOut());
                 assertEquals(clientSiteId, advertisingTokenInput.sourcePublisher.siteId);
                 assertArrayEquals(getRawUidFromIdentity(IdentityType.Email, emailAddress, firstLevelSalt, rotatingSalt123.getSalt()), advertisingTokenInput.rawUidIdentity.rawUid);
 
@@ -1586,8 +1586,8 @@ public class UIDOperatorVerticleTest {
 
                     AdvertisingTokenInput advertisingTokenInput = validateAndGetToken(encoder, body, IdentityType.Email);
 
-                    assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenGenerated());
-                    assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenOptedOut());
+                    assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenGenerated());
+                    assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenOptedOut());
                     assertEquals(clientSiteId, advertisingTokenInput.sourcePublisher.siteId);
                     assertArrayEquals(getRawUidFromIdentity(IdentityType.Email, emailAddress, firstLevelSalt, rotatingSalt123.getSalt()), advertisingTokenInput.rawUidIdentity.rawUid);
 
@@ -2498,8 +2498,8 @@ public class UIDOperatorVerticleTest {
 
             AdvertisingTokenInput advertisingTokenInput = validateAndGetToken(encoder, body, IdentityType.Phone);
 
-            assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenGenerated());
-            assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenOptedOut());
+            assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenGenerated());
+            assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenOptedOut());
             assertEquals(clientSiteId, advertisingTokenInput.sourcePublisher.siteId);
             assertArrayEquals(getRawUidFromIdentity(IdentityType.Phone, phone, firstLevelSalt, rotatingSalt123.getSalt()), advertisingTokenInput.rawUidIdentity.rawUid);
 
@@ -2537,8 +2537,8 @@ public class UIDOperatorVerticleTest {
 
             AdvertisingTokenInput advertisingTokenInput = validateAndGetToken(encoder, body, IdentityType.Phone);
 
-            assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenGenerated());
-            assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenOptedOut());
+            assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenGenerated());
+            assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenOptedOut());
             assertEquals(clientSiteId, advertisingTokenInput.sourcePublisher.siteId);
             assertArrayEquals(getRawUidFromIdentity(IdentityType.Phone, phone, firstLevelSalt, rotatingSalt123.getSalt()), advertisingTokenInput.rawUidIdentity.rawUid);
 
@@ -2581,8 +2581,8 @@ public class UIDOperatorVerticleTest {
 
                 AdvertisingTokenInput advertisingTokenInput = validateAndGetToken(encoder, refreshBody, IdentityType.Phone);
 
-                assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenGenerated());
-                assertFalse(PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits).isClientSideTokenOptedOut());
+                assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenGenerated());
+                assertFalse(PrivacyBits.fromInt(advertisingTokenInput.privacyBits).isClientSideTokenOptedOut());
                 assertEquals(clientSiteId, advertisingTokenInput.sourcePublisher.siteId);
                 assertArrayEquals(getRawUidFromIdentity(IdentityType.Phone, phone, firstLevelSalt, rotatingSalt123.getSalt()), advertisingTokenInput.rawUidIdentity.rawUid);
 
@@ -4010,7 +4010,7 @@ public class UIDOperatorVerticleTest {
 
                     // When we refresh the token the user has opted out.
                     when(optOutStore.getLatestEntry(any(FirstLevelHashIdentity.class)))
-                        .thenReturn(advertisingTokenInput.rawUidIdentity.establishedAt.plusSeconds(1));
+                        .thenReturn(advertisingTokenInput.establishedAt.plusSeconds(1));
 
                     sendTokenRefresh("v2", vertx, testContext, genBody.getString("refresh_token"), genBody.getString("refresh_response_key"), 200, refreshRespJson -> {
                         assertEquals("optout", refreshRespJson.getString("status"));
@@ -4202,7 +4202,7 @@ public class UIDOperatorVerticleTest {
     }
 
     private void assertAreClientSideGeneratedTokens(AdvertisingTokenInput advertisingTokenInput, RefreshTokenInput refreshTokenInput, int siteId, IdentityType identityType, String identity, boolean expectedOptOut) {
-        final PrivacyBits advertisingTokenPrivacyBits = PrivacyBits.fromInt(advertisingTokenInput.rawUidIdentity.privacyBits);
+        final PrivacyBits advertisingTokenPrivacyBits = PrivacyBits.fromInt(advertisingTokenInput.privacyBits);
         final PrivacyBits refreshTokenPrivacyBits = PrivacyBits.fromInt(refreshTokenInput.firstLevelHashIdentity.privacyBits);
 
         final byte[] rawUid = getRawUidFromIdentity(identityType,

--- a/src/test/java/com/uid2/operator/benchmark/BenchmarkCommon.java
+++ b/src/test/java/com/uid2/operator/benchmark/BenchmarkCommon.java
@@ -155,8 +155,7 @@ public class BenchmarkCommon {
         for (int i = 0; i < 65536; i++) {
             final byte[] diiHash = new byte[33];
             new Random().nextBytes(diiHash);
-            arr[i] = new HashedDiiIdentity(IdentityScope.UID2, IdentityType.Email, diiHash, 0,
-                    Instant.now().minusSeconds(120));
+            arr[i] = new HashedDiiIdentity(IdentityScope.UID2, IdentityType.Email, diiHash);
         }
         return arr;
     }

--- a/src/test/java/com/uid2/operator/benchmark/TokenEndecBenchmark.java
+++ b/src/test/java/com/uid2/operator/benchmark/TokenEndecBenchmark.java
@@ -8,6 +8,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,7 +43,7 @@ public class TokenEndecBenchmark {
                     uidService.generateIdentity(new IdentityRequest(
                             publisher,
                             hashedDiiIdentities[i],
-                            OptoutCheckPolicy.DoNotRespect)));
+                            OptoutCheckPolicy.DoNotRespect, 1, Instant.now())));
         }
         return tokens.toArray(new IdentityResponse[tokens.size()]);
     }
@@ -53,7 +54,7 @@ public class TokenEndecBenchmark {
         return uidService.generateIdentity(new IdentityRequest(
                 publisher,
                 hashedDiiIdentities[(idx++) & 65535],
-                OptoutCheckPolicy.DoNotRespect));
+                OptoutCheckPolicy.DoNotRespect, 1, Instant.now()));
     }
 
     @Benchmark


### PR DESCRIPTION
0. Read changes [here ](https://github.com/IABTechLab/uid2-operator/pull/1081/files)first
1. Removed privacyBits and establishedAt from UserIdentity/HashedDiidentity/RawUidIdentity but only kept inside FirstLevelHashIdentity - these fields are only relevant when a first level hash is generated for token generation and then passed along into ad token generation logic.

2. As a result,  privacyBits and establishedAt are generated from either a. in a brand new token generation call (by default should be 1 and the timestamp at the time of the call) b. or, during token refresh logic, these fields will be inherited from previous refresh token.
3. Updated a lot of codes as a result (more refinement required such as not hardcoding the "1, Instant.now()" in a lot of places)