### PR TITLE
UID2-4430 Automatic allocation of cores to vsockpx and operator vertx

### DIFF
--- a/scripts/aws/eks-pod/entrypoint.sh
+++ b/scripts/aws/eks-pod/entrypoint.sh
@@ -27,7 +27,7 @@ function setup_vsockproxy() {
     echo "setup_vsockproxy"
     VSOCK_PROXY=${VSOCK_PROXY:-/home/vsockpx}
     VSOCK_CONFIG=${VSOCK_CONFIG:-/home/proxies.host.yaml}
-    VSOCK_THREADS=${VSOCK_THREADS:-$(( $(nproc) * 2 )) }
+    VSOCK_THREADS=${VSOCK_THREADS:-$(( ( $(nproc) + 1 ) / 2 )) }
     VSOCK_LOG_LEVEL=${VSOCK_LOG_LEVEL:-3}
     echo "starting vsock proxy at $VSOCK_PROXY with $VSOCK_THREADS worker threads..."
     $VSOCK_PROXY -c $VSOCK_CONFIG --workers $VSOCK_THREADS --log-level $VSOCK_LOG_LEVEL --daemon

--- a/scripts/aws/entrypoint.sh
+++ b/scripts/aws/entrypoint.sh
@@ -16,7 +16,7 @@ ifconfig lo 127.0.0.1
 
 # -- start vsock proxy
 echo "Starting vsock proxy..."
-/app/vsockpx --config /app/proxies.nitro.yaml --daemon --workers $(( $(nproc) * 2 )) --log-level 3
+/app/vsockpx --config /app/proxies.nitro.yaml --daemon --workers $(( ( $(nproc) + 3 ) / 4 )) --log-level 3
 
 # -- load config from identity service
 echo "Loading config from identity service via proxy..."

--- a/scripts/aws/make_config.py
+++ b/scripts/aws/make_config.py
@@ -26,7 +26,7 @@ config['core_api_token'] = overrides['api_token']
 config['optout_api_token'] = overrides['api_token']
 
 # number of threads
-config['service_instances'] = thread_count
+config['service_instances'] = int((thread_count + 1) * 2 / 3)
 
 # environment
 if overrides.get('environment') == 'integ':

--- a/scripts/aws/start.sh
+++ b/scripts/aws/start.sh
@@ -81,7 +81,7 @@ function update_allocation() {
 function setup_vsockproxy() {
     VSOCK_PROXY=${VSOCK_PROXY:-/usr/bin/vsockpx}
     VSOCK_CONFIG=${VSOCK_CONFIG:-/etc/uid2operator/proxy.yaml}
-    VSOCK_THREADS=${VSOCK_THREADS:-$(( $(nproc) * 2 )) }
+    VSOCK_THREADS=${VSOCK_THREADS:-$(( ( $(nproc) + 1 ) / 2 )) }
     VSOCK_LOG_LEVEL=${VSOCK_LOG_LEVEL:-3}
     echo "starting vsock proxy at $VSOCK_PROXY with $VSOCK_THREADS worker threads..."
     $VSOCK_PROXY -c $VSOCK_CONFIG --workers $VSOCK_THREADS --log-level $VSOCK_LOG_LEVEL --daemon


### PR DESCRIPTION
- Avoid oversubscribing host and enclave
- Host: half cores to vsockpx
- Enclave: 2/3 cores to operator reactor vertices, 1/4 cores to vsockpx