### PR TITLE
Add configurable debug-mode option into AWS EC2 enclave operator startup

### DIFF
--- a/scripts/aws/UID_CloudFormation.template.yml
+++ b/scripts/aws/UID_CloudFormation.template.yml
@@ -188,6 +188,7 @@ Resources:
           "enclave_cpu_count":6,
           "enclave_memory_mb":24576,
           "environment":"${DeployToEnvironment}"
+          "debug_mode":"false"
         }'
   WorkerRole:
     Type: 'AWS::IAM::Role'


### PR DESCRIPTION
1. Added a `debug_mode` config in secrets manager for aws ec2 start.sh to decide if we need to add --debug-mode param for nitro-cli command

2. When running --debug-mode param, also add --attach-console param Tested enabling it and on Core Service dashboard can see the attestation request with "AAAAAAAA...." enclave id to confirm it is running in enclave mode