### PR TITLE
xuy-UID2-4341-change-log-level Refine response logging

### DIFF
--- a/src/main/java/com/uid2/operator/service/JsonParseUtils.java
+++ b/src/main/java/com/uid2/operator/service/JsonParseUtils.java
@@ -10,7 +10,7 @@ public class JsonParseUtils {
         try {
             outArray = object.getJsonArray(key);
         } catch (ClassCastException e) {
-            ResponseUtil.ClientError(rc, String.format("%s must be an array", key));
+            ResponseUtil.LogInfoAndSend400Response(rc, String.format("%s must be an array", key));
             return null;
         }
         return outArray;

--- a/src/main/java/com/uid2/operator/service/ResponseUtil.java
+++ b/src/main/java/com/uid2/operator/service/ResponseUtil.java
@@ -69,14 +69,12 @@ public class ResponseUtil {
 
     public static void SendClientErrorResponseAndRecordStats(String errorStatus, int statusCode, RoutingContext rc, String message, Integer siteId, TokenResponseStatsCollector.Endpoint endpoint, TokenResponseStatsCollector.ResponseStatus responseStatus, ISiteStore siteProvider, TokenResponseStatsCollector.PlatformType platformType)
     {
-        // 400 error
         if (ResponseStatus.ClientError.equals(errorStatus) ||
                 ResponseStatus.InvalidAppName.equals(errorStatus) ||
                 ResponseStatus.InvalidHttpOrigin.equals(errorStatus))
         {
             LogInfoAndSendResponse(errorStatus, statusCode, rc, message);
         }
-        // 4xx error other than 400
         else {
             LogWarningAndSendResponse(errorStatus, statusCode, rc, message);
         }

--- a/src/main/java/com/uid2/operator/service/ResponseUtil.java
+++ b/src/main/java/com/uid2/operator/service/ResponseUtil.java
@@ -70,7 +70,9 @@ public class ResponseUtil {
     public static void SendClientErrorResponseAndRecordStats(String errorStatus, int statusCode, RoutingContext rc, String message, Integer siteId, TokenResponseStatsCollector.Endpoint endpoint, TokenResponseStatsCollector.ResponseStatus responseStatus, ISiteStore siteProvider, TokenResponseStatsCollector.PlatformType platformType)
     {
         // 400 error
-        if (ResponseStatus.ClientError.equals(errorStatus))
+        if (ResponseStatus.ClientError.equals(errorStatus) ||
+                ResponseStatus.InvalidAppName.equals(errorStatus) ||
+                ResponseStatus.InvalidHttpOrigin.equals(errorStatus))
         {
             LogInfoAndSendResponse(errorStatus, statusCode, rc, message);
         }

--- a/src/main/java/com/uid2/operator/service/ResponseUtil.java
+++ b/src/main/java/com/uid2/operator/service/ResponseUtil.java
@@ -1,7 +1,6 @@
 package com.uid2.operator.service;
 
 import com.uid2.operator.monitoring.TokenResponseStatsCollector;
-import com.uid2.operator.vertx.UIDOperatorVerticle;
 import com.uid2.shared.model.TokenVersion;
 import com.uid2.shared.store.ISiteStore;
 import io.vertx.core.http.HttpHeaders;
@@ -64,19 +63,28 @@ public class ResponseUtil {
         rc.data().put("response", json);
     }
 
-    public static void ClientError(RoutingContext rc, String message) {
-        Warning(ResponseStatus.ClientError, 400, rc, message);
+    public static void LogInfoAndSend400Response(RoutingContext rc, String message) {
+        LogInfoAndSendResponse(ResponseStatus.ClientError, 400, rc, message);
     }
 
     public static void SendClientErrorResponseAndRecordStats(String errorStatus, int statusCode, RoutingContext rc, String message, Integer siteId, TokenResponseStatsCollector.Endpoint endpoint, TokenResponseStatsCollector.ResponseStatus responseStatus, ISiteStore siteProvider, TokenResponseStatsCollector.PlatformType platformType)
     {
-        Warning(errorStatus, statusCode, rc, message);
+        // 400 error
+        if (ResponseStatus.ClientError.equals(errorStatus))
+        {
+            LogInfoAndSendResponse(errorStatus, statusCode, rc, message);
+        }
+        // 4xx error other than 400
+        else {
+            LogWarningAndSendResponse(errorStatus, statusCode, rc, message);
+        }
+
         recordTokenResponseStats(siteId, endpoint, responseStatus, siteProvider, null, platformType);
     }
 
     public static void SendServerErrorResponseAndRecordStats(RoutingContext rc, String message, Integer siteId, TokenResponseStatsCollector.Endpoint endpoint, TokenResponseStatsCollector.ResponseStatus responseStatus, ISiteStore siteProvider, Exception exception, TokenResponseStatsCollector.PlatformType platformType)
     {
-        Error(ResponseStatus.UnknownError, 500, rc, message, exception);
+        LogErrorAndSendResponse(ResponseStatus.UnknownError, 500, rc, message, exception);
         rc.fail(500);
         recordTokenResponseStats(siteId, endpoint, responseStatus, siteProvider, null, platformType);
     }
@@ -97,62 +105,40 @@ public class ResponseUtil {
         return json;
     }
 
-    public static void Error(String errorStatus, int statusCode, RoutingContext rc, String message) {
-        logError(errorStatus, statusCode, message, new RoutingContextReader(rc), rc.request().remoteAddress().hostAddress());
+    public static void LogErrorAndSendResponse(String errorStatus, int statusCode, RoutingContext rc, String message) {
+        String msg = ComposeMessage(errorStatus, statusCode, message, new RoutingContextReader(rc), rc.request().remoteAddress().hostAddress());
+        LOGGER.error(msg);
         final JsonObject json = Response(errorStatus, message);
         rc.response().setStatusCode(statusCode).putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                 .end(json.encode());
     }
 
-    public static void Error(String errorStatus, int statusCode, RoutingContext rc, String message, Exception exception) {
-        logError(errorStatus, statusCode, message, new RoutingContextReader(rc), rc.request().remoteAddress().hostAddress(), exception);
+    public static void LogErrorAndSendResponse(String errorStatus, int statusCode, RoutingContext rc, String message, Exception exception) {
+        String msg = ComposeMessage(errorStatus, statusCode, message, new RoutingContextReader(rc), rc.request().remoteAddress().hostAddress());
+        LOGGER.error(msg, exception);
         final JsonObject json = Response(errorStatus, message);
         rc.response().setStatusCode(statusCode).putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                 .end(json.encode());
     }
 
-    public static void Warning(String status, int statusCode, RoutingContext rc, String message) {
-        logWarning(status, statusCode, message, new RoutingContextReader(rc), rc.request().remoteAddress().hostAddress());
+    public static void LogInfoAndSendResponse(String status, int statusCode, RoutingContext rc, String message) {
+        String msg = ComposeMessage(status, statusCode, message, new RoutingContextReader(rc), rc.request().remoteAddress().hostAddress());
+        LOGGER.info(msg);
         final JsonObject json = Response(status, message);
         rc.response().setStatusCode(statusCode).putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                 .end(json.encode());
     }
 
-    private static void logError(String errorStatus, int statusCode, String message, RoutingContextReader contextReader, String clientAddress) {
-        JsonObject errorJsonObj = JsonObject.of(
-                "errorStatus", errorStatus,
-                "contact", contextReader.getContact(),
-                "siteId", contextReader.getSiteId(),
-                "statusCode", statusCode,
-                "clientAddress", clientAddress,
-                "message", message
-        );
-        final String linkName = contextReader.getLinkName();
-        if (!linkName.isBlank()) {
-            errorJsonObj.put(SecureLinkValidatorService.SERVICE_LINK_NAME, linkName);
-        }
-        final String serviceName = contextReader.getServiceName();
-        if (!serviceName.isBlank()) {
-            errorJsonObj.put(SecureLinkValidatorService.SERVICE_NAME, serviceName);
-        }
-        LOGGER.error("Error response to http request. " + errorJsonObj.encode());
+    public static void LogWarningAndSendResponse(String status, int statusCode, RoutingContext rc, String message) {
+        String msg = ComposeMessage(status, statusCode, message, new RoutingContextReader(rc), rc.request().remoteAddress().hostAddress());
+        LOGGER.warn(msg);
+        final JsonObject json = Response(status, message);
+        rc.response().setStatusCode(statusCode).putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                .end(json.encode());
     }
 
-    private static void logError(String errorStatus, int statusCode, String message, RoutingContextReader contextReader, String clientAddress, Exception exception) {
-        String errorMessage = "Error response to http request. " + JsonObject.of(
-                "errorStatus", errorStatus,
-                "contact", contextReader.getContact(),
-                "siteId", contextReader.getSiteId(),
-                "path", contextReader.getPath(),
-                "statusCode", statusCode,
-                "clientAddress", clientAddress,
-                "message", message
-        ).encode();
-        LOGGER.error(errorMessage, exception);
-    }
-
-    private static void logWarning(String status, int statusCode, String message, RoutingContextReader contextReader, String clientAddress) {
-        JsonObject warnMessageJsonObject = JsonObject.of(
+    private static String ComposeMessage(String status, int statusCode, String message, RoutingContextReader contextReader, String clientAddress) {
+        JsonObject msgJsonObject = JsonObject.of(
                 "errorStatus", status,
                 "contact", contextReader.getContact(),
                 "siteId", contextReader.getSiteId(),
@@ -165,14 +151,22 @@ public class ResponseUtil {
         final String origin = contextReader.getOrigin();
         if (statusCode >= 400 && statusCode < 500) {
             if (referer != null) {
-                warnMessageJsonObject.put("referer", referer);
+                msgJsonObject.put("referer", referer);
             }
             if (origin != null) {
-                warnMessageJsonObject.put("origin", origin);
+                msgJsonObject.put("origin", origin);
             }
         }
-        String warnMessage = "Warning response to http request. " + warnMessageJsonObject.encode();
-        LOGGER.warn(warnMessage);
+
+        final String linkName = contextReader.getLinkName();
+        if (!linkName.isBlank()) {
+            msgJsonObject.put(SecureLinkValidatorService.SERVICE_LINK_NAME, linkName);
+        }
+        final String serviceName = contextReader.getServiceName();
+        if (!serviceName.isBlank()) {
+            msgJsonObject.put(SecureLinkValidatorService.SERVICE_NAME, serviceName);
+        }
+        return "Response to http request. " + msgJsonObject.encode();
     }
 
     public static class ResponseStatus {
@@ -183,6 +177,7 @@ public class ResponseUtil {
         public static final String InvalidToken = "invalid_token";
         public static final String ExpiredToken = "expired_token";
         public static final String GenericError = "error";
+        public static final String InvalidClient = "invalid_client";
         public static final String UnknownError = "unknown";
         public static final String InsufficientUserConsent = "insufficient_user_consent";
         public static final String InvalidHttpOrigin = "invalid_http_origin";

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -569,7 +569,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
         final ClientKey clientKey = AuthMiddleware.getAuthClient(ClientKey.class, rc);
         final int clientSiteId = clientKey.getSiteId();
         if (!clientKey.hasValidSiteId()) {
-            ResponseUtil.Warning("invalid_client", 401, rc, "Unexpected client site id " + Integer.toString(clientSiteId));
+            ResponseUtil.LogWarningAndSendResponse(ResponseStatus.InvalidClient, 401, rc, "Unexpected client site id " + Integer.toString(clientSiteId));
             return;
         }
 
@@ -820,13 +820,13 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                     ResponseUtil.SuccessNoBody(ResponseStatus.OptOut, rc);
                 } else if (!AuthMiddleware.isAuthenticated(rc)) {
                     // unauthenticated clients get a generic error
-                    ResponseUtil.Warning(ResponseStatus.GenericError, 400, rc, "Error refreshing token");
+                    ResponseUtil.LogWarningAndSendResponse(ResponseStatus.GenericError, 400, rc, "Error refreshing token");
                 } else if (r.isInvalidToken()) {
-                    ResponseUtil.Warning(ResponseStatus.InvalidToken, 400, rc, "Invalid Token presented " + tokenList.get(0));
+                    ResponseUtil.LogWarningAndSendResponse(ResponseStatus.InvalidToken, 400, rc, "Invalid Token presented " + tokenList.get(0));
                 } else if (r.isExpired()) {
-                    ResponseUtil.Warning(ResponseStatus.ExpiredToken, 400, rc, "Expired Token presented");
+                    ResponseUtil.LogWarningAndSendResponse(ResponseStatus.ExpiredToken, 400, rc, "Expired Token presented");
                 } else {
-                    ResponseUtil.Error(ResponseStatus.UnknownError, 500, rc, "Unknown State");
+                    ResponseUtil.LogErrorAndSendResponse(ResponseStatus.UnknownError, 500, rc, "Unknown State");
                 }
             } else {
                 ResponseUtil.Success(rc, toJsonV1(r.getTokens()));
@@ -852,15 +852,15 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                     ResponseUtil.SuccessNoBodyV2(ResponseStatus.OptOut, rc);
                 } else if (!AuthMiddleware.isAuthenticated(rc)) {
                     // unauthenticated clients get a generic error
-                    ResponseUtil.Warning(ResponseStatus.GenericError, 400, rc, "Error refreshing token");
+                    ResponseUtil.LogWarningAndSendResponse(ResponseStatus.GenericError, 400, rc, "Error refreshing token");
                 } else if (r.isInvalidToken()) {
-                    ResponseUtil.Warning(ResponseStatus.InvalidToken, 400, rc, "Invalid Token presented");
+                    ResponseUtil.LogWarningAndSendResponse(ResponseStatus.InvalidToken, 400, rc, "Invalid Token presented");
                 } else if (r.isExpired()) {
-                    ResponseUtil.Warning(ResponseStatus.ExpiredToken, 400, rc, "Expired Token presented");
+                    ResponseUtil.LogWarningAndSendResponse(ResponseStatus.ExpiredToken, 400, rc, "Expired Token presented");
                 } else if (r.noActiveKey()) {
                     SendServerErrorResponseAndRecordStats(rc, "No active encryption key available", siteId, TokenResponseStatsCollector.Endpoint.RefreshV2, TokenResponseStatsCollector.ResponseStatus.NoActiveKey, siteProvider, new KeyManager.NoActiveKeyException("No active encryption key available"), platformType);
                 } else {
-                    ResponseUtil.Error(ResponseStatus.UnknownError, 500, rc, "Unknown State");
+                    ResponseUtil.LogErrorAndSendResponse(ResponseStatus.UnknownError, 500, rc, "Unknown State");
                 }
             } else {
                 ResponseUtil.SuccessV2(rc, toJsonV1(r.getTokens()));
@@ -894,7 +894,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                 ResponseUtil.Success(rc, Boolean.FALSE);
             }
         } catch (ClientInputValidationException cie) {
-            ResponseUtil.Warning(ResponseStatus.InvalidToken, 400, rc, "Invalid Token presented");
+            ResponseUtil.LogWarningAndSendResponse(ResponseStatus.InvalidToken, 400, rc, "Invalid Token presented");
         } catch (Exception e) {
             LOGGER.error("Unknown error while validating token", e);
             rc.fail(500);
@@ -1120,7 +1120,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                 }
             });
         } else {
-            ResponseUtil.Warning(ResponseStatus.InvalidToken, 400, rc, "Invalid Token presented " + input);
+            ResponseUtil.LogWarningAndSendResponse(ResponseStatus.InvalidToken, 400, rc, "Invalid Token presented " + input);
         }
     }
 
@@ -1143,7 +1143,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
             });
             return promise.future();
         } else {
-            ResponseUtil.Warning(ResponseStatus.InvalidToken, 400, rc, "Invalid Token presented " + input);
+            ResponseUtil.LogWarningAndSendResponse(ResponseStatus.InvalidToken, 400, rc, "Invalid Token presented " + input);
             return Future.failedFuture("");
         }
     }
@@ -1165,7 +1165,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                 rc.fail(500);
             }
         } else {
-            ResponseUtil.Warning(ResponseStatus.InvalidToken, 400, rc, "Invalid Token presented " + input);
+            ResponseUtil.LogWarningAndSendResponse(ResponseStatus.InvalidToken, 400, rc, "Invalid Token presented " + input);
         }
     }
 
@@ -1178,7 +1178,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                 sinceTimestamp = ld.toInstant(ZoneOffset.UTC);
                 LOGGER.info(String.format("identity bucket endpoint is called with since_timestamp %s and site id %s", ld, AuthMiddleware.getAuthClient(rc).getSiteId()));
             } catch (Exception e) {
-                ResponseUtil.ClientError(rc, "invalid date, must conform to ISO 8601");
+                ResponseUtil.LogInfoAndSend400Response(rc, "invalid date, must conform to ISO 8601");
                 return;
             }
             final List<SaltEntry> modified = this.idService.getModifiedBuckets(sinceTimestamp);
@@ -1195,7 +1195,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                 ResponseUtil.Success(rc, resp);
             }
         } else {
-            ResponseUtil.ClientError(rc, "missing parameter since_timestamp");
+            ResponseUtil.LogInfoAndSend400Response(rc, "missing parameter since_timestamp");
         }
     }
 
@@ -1210,7 +1210,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                 sinceTimestamp = ld.toInstant(ZoneOffset.UTC);
                 LOGGER.info(String.format("identity bucket endpoint is called with since_timestamp %s and site id %s", ld, AuthMiddleware.getAuthClient(rc).getSiteId()));
             } catch (Exception e) {
-                ResponseUtil.ClientError(rc, "invalid date, must conform to ISO 8601");
+                ResponseUtil.LogInfoAndSend400Response(rc, "invalid date, must conform to ISO 8601");
                 return;
             }
             final List<SaltEntry> modified = this.idService.getModifiedBuckets(sinceTimestamp);
@@ -1227,7 +1227,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                 ResponseUtil.SuccessV2(rc, resp);
             }
         } else {
-            ResponseUtil.ClientError(rc, "missing parameter since_timestamp");
+            ResponseUtil.LogInfoAndSend400Response(rc, "missing parameter since_timestamp");
         }
     }
 
@@ -1245,7 +1245,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
             jsonObject.put("bucket_id", mappedIdentity.bucketId);
             ResponseUtil.Success(rc, jsonObject);
         } catch (Exception e) {
-            ResponseUtil.Error(ResponseStatus.UnknownError, 500, rc, "Unknown State", e);
+            ResponseUtil.LogErrorAndSendResponse(ResponseStatus.UnknownError, 500, rc, "Unknown State", e);
         }
     }
 
@@ -1359,10 +1359,10 @@ public class UIDOperatorVerticle extends AbstractVerticle {
     private boolean isTokenInputValid(InputUtil.InputVal input, RoutingContext rc) {
         if (input == null) {
             String message = this.phoneSupport ? ERROR_INVALID_INPUT_WITH_PHONE_SUPPORT : ERROR_INVALID_INPUT_EMAIL_MISSING;
-            ResponseUtil.ClientError(rc, message);
+            ResponseUtil.LogInfoAndSend400Response(rc, message);
             return false;
         } else if (!input.isValid()) {
-            ResponseUtil.ClientError(rc, "Invalid Identifier");
+            ResponseUtil.LogInfoAndSend400Response(rc, "Invalid Identifier");
             return false;
         }
         return true;
@@ -1374,11 +1374,11 @@ public class UIDOperatorVerticle extends AbstractVerticle {
         final JsonArray emailHashes = obj.getJsonArray("email_hash");
         // FIXME TODO. Avoid Double Iteration. Turn to a decorator pattern
         if (emails == null && emailHashes == null) {
-            ResponseUtil.ClientError(rc, ERROR_INVALID_INPUT_EMAIL_MISSING);
+            ResponseUtil.LogInfoAndSend400Response(rc, ERROR_INVALID_INPUT_EMAIL_MISSING);
             return null;
         } else if (emails != null && !emails.isEmpty()) {
             if (emailHashes != null && !emailHashes.isEmpty()) {
-                ResponseUtil.ClientError(rc, ERROR_INVALID_INPUT_EMAIL_TWICE);
+                ResponseUtil.LogInfoAndSend400Response(rc, ERROR_INVALID_INPUT_EMAIL_TWICE);
                 return null;
             }
             return createInputList(emails, false);
@@ -1391,7 +1391,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
     private InputUtil.InputVal[] getIdentityBulkInputV1(RoutingContext rc) {
         final JsonObject obj = rc.body().asJsonObject();
         if(obj.isEmpty()) {
-            ResponseUtil.ClientError(rc, ERROR_INVALID_INPUT_WITH_PHONE_SUPPORT);
+            ResponseUtil.LogInfoAndSend400Response(rc, ERROR_INVALID_INPUT_WITH_PHONE_SUPPORT);
             return null;
         }
         final JsonArray emails = JsonParseUtils.parseArray(obj, "email", rc);
@@ -1423,7 +1423,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
         }
 
         if (validInputs == 0 || nonEmptyInputs > 1) {
-            ResponseUtil.ClientError(rc, ERROR_INVALID_INPUT_WITH_PHONE_SUPPORT);
+            ResponseUtil.LogInfoAndSend400Response(rc, ERROR_INVALID_INPUT_WITH_PHONE_SUPPORT);
             return null;
         }
 
@@ -1495,7 +1495,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
             final JsonObject resp = handleIdentityMapCommon(rc, inputList);
             ResponseUtil.Success(rc, resp);
         } catch (Exception e) {
-            ResponseUtil.Error(ResponseStatus.UnknownError, 500, rc, "Unknown error while mapping batched identity", e);
+            ResponseUtil.LogErrorAndSendResponse(ResponseStatus.UnknownError, 500, rc, "Unknown error while mapping batched identity", e);
         }
     }
 
@@ -1504,22 +1504,22 @@ public class UIDOperatorVerticle extends AbstractVerticle {
             final InputUtil.InputVal[] inputList = getIdentityMapV2Input(rc);
             if (inputList == null) {
                 if (this.phoneSupport)
-                    ResponseUtil.ClientError(rc, ERROR_INVALID_INPUT_WITH_PHONE_SUPPORT);
+                    ResponseUtil.LogInfoAndSend400Response(rc, ERROR_INVALID_INPUT_WITH_PHONE_SUPPORT);
                 else
-                    ResponseUtil.ClientError(rc, ERROR_INVALID_INPUT_EMAIL_MISSING);
+                    ResponseUtil.LogInfoAndSend400Response(rc, ERROR_INVALID_INPUT_EMAIL_MISSING);
                 return;
             }
 
             JsonObject requestJsonObject = (JsonObject) rc.data().get(REQUEST);
             if (!this.secureLinkValidatorService.validateRequest(rc, requestJsonObject, Role.MAPPER)) {
-                ResponseUtil.Error(ResponseStatus.Unauthorized, HttpStatus.SC_UNAUTHORIZED, rc, "Invalid link_id");
+                ResponseUtil.LogErrorAndSendResponse(ResponseStatus.Unauthorized, HttpStatus.SC_UNAUTHORIZED, rc, "Invalid link_id");
                 return;
             }
 
             final JsonObject resp = handleIdentityMapCommon(rc, inputList);
             ResponseUtil.SuccessV2(rc, resp);
         } catch (Exception e) {
-            ResponseUtil.Error(ResponseStatus.UnknownError, 500, rc, "Unknown error while mapping identity v2", e);
+            ResponseUtil.LogErrorAndSendResponse(ResponseStatus.UnknownError, 500, rc, "Unknown error while mapping identity v2", e);
         }
     }
 
@@ -1572,11 +1572,11 @@ public class UIDOperatorVerticle extends AbstractVerticle {
             final JsonArray emails = obj.getJsonArray("email");
             final JsonArray emailHashes = obj.getJsonArray("email_hash");
             if (emails == null && emailHashes == null) {
-                ResponseUtil.ClientError(rc, ERROR_INVALID_INPUT_EMAIL_MISSING);
+                ResponseUtil.LogInfoAndSend400Response(rc, ERROR_INVALID_INPUT_EMAIL_MISSING);
                 return;
             } else if (emails != null && !emails.isEmpty()) {
                 if (emailHashes != null && !emailHashes.isEmpty()) {
-                    ResponseUtil.ClientError(rc, ERROR_INVALID_INPUT_EMAIL_TWICE);
+                    ResponseUtil.LogInfoAndSend400Response(rc, ERROR_INVALID_INPUT_EMAIL_TWICE);
                     return;
                 }
                 inputList = createInputList(emails, false);
@@ -1678,16 +1678,16 @@ public class UIDOperatorVerticle extends AbstractVerticle {
     private List<String> parseOptoutStatusRequestPayload(RoutingContext rc) {
         final JsonObject requestObj = (JsonObject) rc.data().get("request");
         if (requestObj == null) {
-            ResponseUtil.Error(ResponseStatus.ClientError, HttpStatus.SC_BAD_REQUEST, rc, "Invalid request body");
+            ResponseUtil.LogErrorAndSendResponse(ResponseStatus.ClientError, HttpStatus.SC_BAD_REQUEST, rc, "Invalid request body");
             return null;
         }
         final JsonArray rawUidsJsonArray = requestObj.getJsonArray("advertising_ids");
         if (rawUidsJsonArray == null) {
-            ResponseUtil.Error(ResponseStatus.ClientError, HttpStatus.SC_BAD_REQUEST, rc, "Required Parameter Missing: advertising_ids");
+            ResponseUtil.LogErrorAndSendResponse(ResponseStatus.ClientError, HttpStatus.SC_BAD_REQUEST, rc, "Required Parameter Missing: advertising_ids");
             return null;
         }
         if (rawUidsJsonArray.size() > optOutStatusMaxRequestSize) {
-            ResponseUtil.Error(ResponseStatus.ClientError, HttpStatus.SC_BAD_REQUEST, rc, "Request payload is too large");
+            ResponseUtil.LogErrorAndSendResponse(ResponseStatus.ClientError, HttpStatus.SC_BAD_REQUEST, rc, "Request payload is too large");
             return null;
         }
         List<String> rawUID2sInputList = new ArrayList<>(rawUidsJsonArray.size());
@@ -1721,7 +1721,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
             ResponseUtil.SuccessV2(rc, bodyJsonObj);
             recordOptOutStatusEndpointStats(rc, rawUID2sInput.size(), optedOutJsonArray.size());
         } catch (Exception e) {
-            ResponseUtil.Error(ResponseStatus.UnknownError, 500, rc,
+            ResponseUtil.LogErrorAndSendResponse(ResponseStatus.UnknownError, 500, rc,
                     "Unknown error while getting optout status", e);
         }
     }

--- a/src/main/java/com/uid2/operator/vertx/V2PayloadHandler.java
+++ b/src/main/java/com/uid2/operator/vertx/V2PayloadHandler.java
@@ -51,7 +51,7 @@ public class V2PayloadHandler {
 
         V2RequestUtil.V2Request request = V2RequestUtil.parseRequest(rc.body().asString(), AuthMiddleware.getAuthClient(ClientKey.class, rc), new InstantClock());
         if (!request.isValid()) {
-            ResponseUtil.ClientError(rc, request.errorMessage);
+            ResponseUtil.LogInfoAndSend400Response(rc, request.errorMessage);
             return;
         }
         rc.data().put("request", request.payload);
@@ -69,7 +69,7 @@ public class V2PayloadHandler {
 
         V2RequestUtil.V2Request request = V2RequestUtil.parseRequest(rc.body().asString(), AuthMiddleware.getAuthClient(ClientKey.class, rc), new InstantClock());
         if (!request.isValid()) {
-            ResponseUtil.ClientError(rc, request.errorMessage);
+            ResponseUtil.LogInfoAndSend400Response(rc, request.errorMessage);
             return;
         }
         rc.data().put("request", request.payload);
@@ -110,7 +110,7 @@ public class V2PayloadHandler {
         }
         catch (Exception ex){
             LOGGER.error("Failed to generate token", ex);
-            ResponseUtil.Error(ResponseUtil.ResponseStatus.GenericError, 500, rc, "");
+            ResponseUtil.LogErrorAndSendResponse(ResponseUtil.ResponseStatus.GenericError, 500, rc, "");
         }
     }
 
@@ -163,7 +163,7 @@ public class V2PayloadHandler {
         }
         catch (Exception ex){
             LOGGER.error("Failed to refresh token", ex);
-            ResponseUtil.Error(ResponseUtil.ResponseStatus.GenericError, 500, rc, "");
+            ResponseUtil.LogErrorAndSendResponse(ResponseUtil.ResponseStatus.GenericError, 500, rc, "");
         }
     }
 
@@ -199,7 +199,7 @@ public class V2PayloadHandler {
             writeResponse(rc, request.nonce, respJson, request.encryptionKey);
         } catch (Exception ex) {
             LOGGER.error("Failed to generate response", ex);
-            ResponseUtil.Error(ResponseUtil.ResponseStatus.GenericError, 500, rc, "");
+            ResponseUtil.LogErrorAndSendResponse(ResponseUtil.ResponseStatus.GenericError, 500, rc, "");
         }
     }
 }

--- a/src/test/java/com/uid2/operator/service/ResponseUtilTest.java
+++ b/src/test/java/com/uid2/operator/service/ResponseUtilTest.java
@@ -42,12 +42,13 @@ class ResponseUtilTest {
 
     @Test
     void logsErrorWithNoExtraDetails() {
-        ResponseUtil.Error("Some error status", 500, rc, "Some error message");
+        ResponseUtil.LogErrorAndSendResponse("Some error status", 500, rc, "Some error message");
 
-        String expected = "Error response to http request. {" +
+        String expected = "Response to http request. {" +
                 "\"errorStatus\":\"Some error status\"," +
                 "\"contact\":null," +
                 "\"siteId\":null," +
+                "\"path\":null," +
                 "\"statusCode\":500," +
                 "\"clientAddress\":null," +
                 "\"message\":\"Some error message\"" +
@@ -65,12 +66,13 @@ class ResponseUtilTest {
         when(mockAuthorizable.getSiteId()).thenReturn(10);
         when(rc.data().get("api-client")).thenReturn(mockAuthorizable);
 
-        ResponseUtil.Error("Some error status", 500, rc, "Some error message");
+        ResponseUtil.LogErrorAndSendResponse("Some error status", 500, rc, "Some error message");
 
-        String expected = "Error response to http request. {" +
+        String expected = "Response to http request. {" +
                 "\"errorStatus\":\"Some error status\"," +
                 "\"contact\":\"Test Contract\"," +
                 "\"siteId\":10," +
+                "\"path\":null," +
                 "\"statusCode\":500," +
                 "\"clientAddress\":null," +
                 "\"message\":\"Some error message\"" +
@@ -83,12 +85,13 @@ class ResponseUtilTest {
     void logsErrorWithSiteIdFromContext() {
         when(rc.get(Const.RoutingContextData.SiteId)).thenReturn(20);
 
-        ResponseUtil.Error("Some error status", 500, rc, "Some error message");
+        ResponseUtil.LogErrorAndSendResponse("Some error status", 500, rc, "Some error message");
 
-        String expected = "Error response to http request. {" +
+        String expected = "Response to http request. {" +
                 "\"errorStatus\":\"Some error status\"," +
                 "\"contact\":null," +
                 "\"siteId\":20," +
+                "\"path\":null," +
                 "\"statusCode\":500," +
                 "\"clientAddress\":null," +
                 "\"message\":\"Some error message\"" +
@@ -104,12 +107,13 @@ class ResponseUtilTest {
 
         when(rc.request().remoteAddress()).thenReturn(socket);
 
-        ResponseUtil.Error("Some error status", 500, rc, "Some error message");
+        ResponseUtil.LogErrorAndSendResponse("Some error status", 500, rc, "Some error message");
 
-        String expected = "Error response to http request. {" +
+        String expected = "Response to http request. {" +
                 "\"errorStatus\":\"Some error status\"," +
                 "\"contact\":null," +
                 "\"siteId\":null," +
+                "\"path\":null," +
                 "\"statusCode\":500," +
                 "\"clientAddress\":\"192.168.10.10\"," +
                 "\"message\":\"Some error message\"" +
@@ -124,11 +128,12 @@ class ResponseUtilTest {
         when(rc1.get(SecureLinkValidatorService.SERVICE_LINK_NAME, "")).thenReturn("TestLink1");
         when(rc1.get(SecureLinkValidatorService.SERVICE_NAME, "")).thenReturn("TestService1");
 
-        ResponseUtil.Error("Some error status", 500, rc1, "Some error message");
-        String expected = "Error response to http request. {" +
+        ResponseUtil.LogErrorAndSendResponse("Some error status", 500, rc1, "Some error message");
+        String expected = "Response to http request. {" +
                 "\"errorStatus\":\"Some error status\"," +
                 "\"contact\":null," +
                 "\"siteId\":null," +
+                "\"path\":null," +
                 "\"statusCode\":500," +
                 "\"clientAddress\":null," +
                 "\"message\":\"Some error message\"," +
@@ -144,9 +149,9 @@ class ResponseUtilTest {
         when(request.getHeader("origin")).thenReturn("testOriginHeader");
         when(rc.request()).thenReturn(request);
 
-        ResponseUtil.Warning("Some error status", 400, rc, "Some error message");
+        ResponseUtil.LogInfoAndSendResponse("Some error status", 400, rc, "Some error message");
 
-        String expected = "Warning response to http request. {" +
+        String expected = "Response to http request. {" +
                 "\"errorStatus\":\"Some error status\"," +
                 "\"contact\":null," +
                 "\"siteId\":null," +
@@ -165,9 +170,9 @@ class ResponseUtilTest {
         when(request.getHeader("origin")).thenReturn(null);
         when(rc.request()).thenReturn(request);
 
-        ResponseUtil.Warning("Some error status", 400, rc, "Some error message");
+        ResponseUtil.LogWarningAndSendResponse("Some error status", 400, rc, "Some error message");
 
-        String expected = "Warning response to http request. {" +
+        String expected = "Response to http request. {" +
                 "\"errorStatus\":\"Some error status\"," +
                 "\"contact\":null," +
                 "\"siteId\":null," +
@@ -185,9 +190,9 @@ class ResponseUtilTest {
         when(request.getHeader("referer")).thenReturn("testRefererHeader");
         when(rc.request()).thenReturn(request);
 
-        ResponseUtil.Warning("Some error status", 400, rc, "Some error message");
+        ResponseUtil.LogInfoAndSendResponse("Some error status", 400, rc, "Some error message");
 
-        String expected = "Warning response to http request. {" +
+        String expected = "Response to http request. {" +
                 "\"errorStatus\":\"Some error status\"," +
                 "\"contact\":null," +
                 "\"siteId\":null," +
@@ -206,9 +211,9 @@ class ResponseUtilTest {
         when(request.getHeader("referer")).thenReturn(null);
         when(rc.request()).thenReturn(request);
 
-        ResponseUtil.Warning("Some error status", 400, rc, "Some error message");
+        ResponseUtil.LogWarningAndSendResponse("Some error status", 400, rc, "Some error message");
 
-        String expected = "Warning response to http request. {" +
+        String expected = "Response to http request. {" +
                 "\"errorStatus\":\"Some error status\"," +
                 "\"contact\":null," +
                 "\"siteId\":null," +


### PR DESCRIPTION
1. Refine response logging, client error, invalid http origin, and invalid app name responses are logged as info, other responses are still logged as warning.
2. Simplify and remove duplication of the message composing logic

The logging and sending response logic might be further separated into distinct functions, to scope the current MR, left to future optimization.

Test
Unit Test

 