### PR TITLE
Use correct raw UID version for UID2 UIDOperatorVerticleTest and rename identityV3Enabled to rawUidV3Enabled

### DIFF
--- a/src/main/java/com/uid2/operator/service/UIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/UIDOperatorService.java
@@ -47,7 +47,8 @@ public class UIDOperatorService implements IUIDOperatorService {
 
     private final OperatorIdentity operatorIdentity;
     private final TokenVersion refreshTokenVersion;
-    private final boolean identityV3Enabled;
+    // if we use Raw UID v3 format for the raw UID2/EUIDs generated in this operator
+    private final boolean rawUidV3Enabled;
 
     private final Handler<Boolean> saltRetrievalResponseHandler;
 
@@ -90,7 +91,7 @@ public class UIDOperatorService implements IUIDOperatorService {
         }
 
         this.refreshTokenVersion = TokenVersion.V3;
-        this.identityV3Enabled = config.getBoolean("identity_v3", false);
+        this.rawUidV3Enabled = config.getBoolean("identity_v3", false);
     }
 
     @Override
@@ -230,7 +231,7 @@ public class UIDOperatorService implements IUIDOperatorService {
         final SaltEntry rotatingSalt = getSaltProviderSnapshot(asOf).getRotatingSalt(firstLevelHashIdentity.id);
 
         return new MappedIdentity(
-                this.identityV3Enabled
+                this.rawUidV3Enabled
                     ? TokenUtils.getAdvertisingIdV3(firstLevelHashIdentity.identityScope, firstLevelHashIdentity.identityType, firstLevelHashIdentity.id, rotatingSalt.getSalt())
                     : TokenUtils.getAdvertisingIdV2(firstLevelHashIdentity.id, rotatingSalt.getSalt()),
                 rotatingSalt.getHashedId());

--- a/src/test/java/com/uid2/operator/EUIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/EUIDOperatorVerticleTest.java
@@ -21,6 +21,8 @@ public class EUIDOperatorVerticleTest extends UIDOperatorVerticleTest {
     @Override
     protected IdentityScope getIdentityScope() { return IdentityScope.EUID; }
     @Override
+    protected boolean useIdentityV3() { return true; }
+    @Override
     protected void addAdditionalTokenGenerateParams(JsonObject payload) {
         if (payload != null && !payload.containsKey("tcf_consent_string")) {
             payload.put("tcf_consent_string", "CPehNtWPehNtWABAMBFRACBoALAAAEJAAIYgAKwAQAKgArABAAqAAA");

--- a/src/test/java/com/uid2/operator/EUIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/EUIDOperatorVerticleTest.java
@@ -21,7 +21,7 @@ public class EUIDOperatorVerticleTest extends UIDOperatorVerticleTest {
     @Override
     protected IdentityScope getIdentityScope() { return IdentityScope.EUID; }
     @Override
-    protected boolean useIdentityV3() { return true; }
+    protected boolean useRawUidV3() { return true; }
     @Override
     protected void addAdditionalTokenGenerateParams(JsonObject payload) {
         if (payload != null && !payload.containsKey("tcf_consent_string")) {

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -665,7 +665,7 @@ public class UIDOperatorVerticleTest {
 
     protected TokenVersion getTokenVersion() {return TokenVersion.V4;}
 
-    final boolean useIdentityV3() { return getTokenVersion() != TokenVersion.V2; }
+    protected boolean useIdentityV3() { return false; }
     protected IdentityScope getIdentityScope() { return IdentityScope.UID2; }
     protected void addAdditionalTokenGenerateParams(JsonObject payload) {}
 
@@ -816,7 +816,9 @@ public class UIDOperatorVerticleTest {
         final String advertisingTokenString = body.getString("advertising_token");
         validateAdvertisingToken(advertisingTokenString, getTokenVersion(), getIdentityScope(), identityType);
         AdvertisingToken advertisingToken = encoder.decodeAdvertisingToken(advertisingTokenString);
-        if (getTokenVersion() == TokenVersion.V4) {
+
+        // without useIdentityV3() it the assert will fail as there's no IdentityType in raw UID2 v2 generated v4 token
+        if (useIdentityV3() && getTokenVersion() == TokenVersion.V4) {
             assertEquals(identityType, advertisingToken.userIdentity.identityType);
         }
         return advertisingToken;

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -817,7 +817,8 @@ public class UIDOperatorVerticleTest {
         validateAdvertisingToken(advertisingTokenString, getTokenVersion(), getIdentityScope(), identityType);
         AdvertisingToken advertisingToken = encoder.decodeAdvertisingToken(advertisingTokenString);
 
-        // without useIdentityV3() it the assert will fail as there's no IdentityType in raw UID2 v2 generated v4 token
+        // without useIdentityV3() the assert will be trigger as there's no IdentityType in v4 token generated with
+        // a raw UID v2 as old raw UID format doesn't store the identity type (and scope)
         if (useIdentityV3() && getTokenVersion() == TokenVersion.V4) {
             assertEquals(identityType, advertisingToken.userIdentity.identityType);
         }

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -13,7 +13,6 @@ import com.uid2.operator.util.PrivacyBits;
 import com.uid2.operator.util.Tuple;
 import com.uid2.operator.vertx.OperatorShutdownHandler;
 import com.uid2.operator.vertx.UIDOperatorVerticle;
-import com.uid2.operator.vertx.ClientInputValidationException;
 import com.uid2.shared.Utils;
 import com.uid2.shared.auth.ClientKey;
 import com.uid2.shared.auth.Keyset;
@@ -27,9 +26,7 @@ import com.uid2.shared.secret.KeyHashResult;
 import com.uid2.shared.secret.KeyHasher;
 import com.uid2.shared.store.*;
 import com.uid2.shared.store.reader.RotatingKeysetProvider;
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -158,7 +155,7 @@ public class UIDOperatorVerticleTest {
         config.put(Const.Config.SharingTokenExpiryProp, 60 * 60 * 24 * 30);
 
         config.put("identity_scope", getIdentityScope().toString());
-        config.put("identity_v3", useIdentityV3());
+        config.put("identity_v3", useRawUidV3());
         config.put("client_side_token_generate", true);
         config.put("key_sharing_endpoint_provide_app_names", true);
         config.put("client_side_token_generate_log_invalid_http_origins", true);
@@ -622,23 +619,23 @@ public class UIDOperatorVerticleTest {
     }
 
     private byte[] getAdvertisingIdFromIdentity(IdentityType identityType, String identityString, String firstLevelSalt, String rotatingSalt) {
-        return getRawUid(identityType, identityString, firstLevelSalt, rotatingSalt, getIdentityScope(), useIdentityV3());
+        return getRawUid(identityType, identityString, firstLevelSalt, rotatingSalt, getIdentityScope(), useRawUidV3());
     }
 
-    private static byte[] getRawUid(IdentityType identityType, String identityString, String firstLevelSalt, String rotatingSalt, IdentityScope identityScope, boolean useIdentityV3) {
-        return !useIdentityV3
+    private static byte[] getRawUid(IdentityType identityType, String identityString, String firstLevelSalt, String rotatingSalt, IdentityScope identityScope, boolean useRawUidV3) {
+        return !useRawUidV3
                 ? TokenUtils.getAdvertisingIdV2FromIdentity(identityString, firstLevelSalt, rotatingSalt)
                 : TokenUtils.getAdvertisingIdV3FromIdentity(identityScope, identityType, identityString, firstLevelSalt, rotatingSalt);
     }
 
-    public static byte[] getRawUid(IdentityType identityType, String identityString, IdentityScope identityScope, boolean useIdentityV3) {
-        return !useIdentityV3
+    public static byte[] getRawUid(IdentityType identityType, String identityString, IdentityScope identityScope, boolean useRawUidV3) {
+        return !useRawUidV3
                 ? TokenUtils.getAdvertisingIdV2FromIdentity(identityString, firstLevelSalt, rotatingSalt123.getSalt())
                 : TokenUtils.getAdvertisingIdV3FromIdentity(identityScope, identityType, identityString, firstLevelSalt, rotatingSalt123.getSalt());
     }
 
     private byte[] getAdvertisingIdFromIdentityHash(IdentityType identityType, String identityString, String firstLevelSalt, String rotatingSalt) {
-        return !useIdentityV3()
+        return !useRawUidV3()
                 ? TokenUtils.getAdvertisingIdV2FromIdentityHash(identityString, firstLevelSalt, rotatingSalt)
                 : TokenUtils.getAdvertisingIdV3FromIdentityHash(getIdentityScope(), identityType, identityString, firstLevelSalt, rotatingSalt);
     }
@@ -665,7 +662,7 @@ public class UIDOperatorVerticleTest {
 
     protected TokenVersion getTokenVersion() {return TokenVersion.V4;}
 
-    protected boolean useIdentityV3() { return false; }
+    protected boolean useRawUidV3() { return false; }
     protected IdentityScope getIdentityScope() { return IdentityScope.UID2; }
     protected void addAdditionalTokenGenerateParams(JsonObject payload) {}
 
@@ -819,7 +816,7 @@ public class UIDOperatorVerticleTest {
 
         // without useIdentityV3() the assert will be trigger as there's no IdentityType in v4 token generated with
         // a raw UID v2 as old raw UID format doesn't store the identity type (and scope)
-        if (useIdentityV3() && getTokenVersion() == TokenVersion.V4) {
+        if (useRawUidV3() && getTokenVersion() == TokenVersion.V4) {
             assertEquals(identityType, advertisingToken.userIdentity.identityType);
         }
         return advertisingToken;


### PR DESCRIPTION
1. From an [PR ](https://github.com/IABTechLab/uid2-operator/pull/1180/files#diff-899d4736c54595d19fe3f5d5b0ab7739007365b694a2c9c66b445e5cf2013c29R666-R668)earlier, it's now only using Raw UID v3 format for UIDOperatorVerticleTest  which is wrong as we still use v2 Raw UID format for UID2 prod.
2. UIDOperatorVerticleTest was incorrectly using Raw UID Format v3 and fixing it requires fixing one of the unit tests 
3. renamed the variable/method useIdentityV3/identityV3Enabled to useRawUidV3/rawUidV3Enabled to be up to date with latest terminlogies
4. Improved TokenEncodingTest#testAdvertisingTokenEncodings to tests all combo's of raw UID and ad token versions