### PR TITLE
sch-UID2-4560 add gauge for number of processing request threads

### DIFF
--- a/src/main/java/com/uid2/operator/Main.java
+++ b/src/main/java/com/uid2/operator/Main.java
@@ -265,7 +265,8 @@ public class Main {
     }
 
     private void run() throws Exception {
-        this.createServiceInstancesMetric();
+        this.createVertxInstancesMetric();
+        this.createVertxEventLoopsMetric();
         Supplier<Verticle> operatorVerticleSupplier = () -> {
             UIDOperatorVerticle verticle = new UIDOperatorVerticle(config, this.clientSideTokenGenerate, siteProvider, clientKeyProvider, clientSideKeypairProvider, getKeyManager(), saltProvider, optOutStore, Clock.systemUTC(), _statsCollectorQueue, new SecureLinkValidatorService(this.serviceLinkProvider, this.serviceProvider), this.shutdownHandler::handleSaltRetrievalResponse);
             return verticle;
@@ -468,9 +469,15 @@ public class Main {
                 .register(globalRegistry);
     }
 
-    private void createServiceInstancesMetric() {
+    private void createVertxInstancesMetric() {
         Gauge.builder("uid2.operator.vertx_service_instances", () -> config.getInteger("service_instances"))
-            .description("gauge for number of request processing threads")
+                .description("gauge for number of vertx service instances requested")
+                .register(Metrics.globalRegistry);
+    }
+
+    private void createVertxEventLoopsMetric() {
+        Gauge.builder("uid2.operator.vertx_event_loop_threads", () -> VertxOptions.DEFAULT_EVENT_LOOP_POOL_SIZE)
+                .description("gauge for number of vertx event loop threads")
                 .register(Metrics.globalRegistry);
     }
 

--- a/src/main/java/com/uid2/operator/Main.java
+++ b/src/main/java/com/uid2/operator/Main.java
@@ -265,6 +265,7 @@ public class Main {
     }
 
     private void run() throws Exception {
+        this.createServiceInstancesMetric();
         Supplier<Verticle> operatorVerticleSupplier = () -> {
             UIDOperatorVerticle verticle = new UIDOperatorVerticle(config, this.clientSideTokenGenerate, siteProvider, clientKeyProvider, clientSideKeypairProvider, getKeyManager(), saltProvider, optOutStore, Clock.systemUTC(), _statsCollectorQueue, new SecureLinkValidatorService(this.serviceLinkProvider, this.serviceProvider), this.shutdownHandler::handleSaltRetrievalResponse);
             return verticle;
@@ -465,6 +466,12 @@ public class Main {
                 .description("application version and status")
                 .tags("version", version)
                 .register(globalRegistry);
+    }
+
+    private void createServiceInstancesMetric() {
+        Gauge.builder("uid2.operator.vertx_service_instances", () -> config.getInteger("service_instances"))
+            .description("gauge for number of request processing threads")
+                .register(Metrics.globalRegistry);
     }
 
     private Map.Entry<UidCoreClient, UidOptOutClient> createUidClients(Vertx vertx, String attestationUrl, String clientApiToken, Handler<Pair<AttestationResponseCode, String>> responseWatcher) throws Exception {


### PR DESCRIPTION
Add gauge for number of vertx service instances and event loop threads in Operator. This will allow us to allocate the appropriate number of CPUs to Operator to reduce latency.