### PR TITLE
Pass DEBUG_MODE to container to allow for better error handling

### DIFF
--- a/scripts/gcp-oidc/Dockerfile
+++ b/scripts/gcp-oidc/Dockerfile
@@ -1,7 +1,7 @@
 # sha from https://hub.docker.com/layers/amd64/eclipse-temurin/21.0.4_7-jre-alpine/images/sha256-8179ddc8a6c5ac9af935020628763b9a5a671e0914976715d2b61b21881cefca
 FROM eclipse-temurin@sha256:8179ddc8a6c5ac9af935020628763b9a5a671e0914976715d2b61b21881cefca
 
-LABEL "tee.launch_policy.allow_env_override"="API_TOKEN_SECRET_NAME,DEPLOYMENT_ENVIRONMENT,CORE_BASE_URL,OPTOUT_BASE_URL"
+LABEL "tee.launch_policy.allow_env_override"="API_TOKEN_SECRET_NAME,DEPLOYMENT_ENVIRONMENT,CORE_BASE_URL,OPTOUT_BASE_URL,DEBUG_MODE,SKIP_VALIDATIONS"
 LABEL "tee.launch_policy.log_redirect"="always"
 
 # Install Packages

--- a/scripts/gcp-oidc/terraform/main.tf
+++ b/scripts/gcp-oidc/terraform/main.tf
@@ -106,6 +106,7 @@ resource "google_compute_instance_template" "uid_operator" {
     tee-image-reference            = var.uid_operator_image
     tee-container-log-redirect     = true
     tee-restart-policy             = "Never"
+    tee-env-DEBUG_MODE             = var.debug_mode
     tee-env-DEPLOYMENT_ENVIRONMENT = var.uid_deployment_env
     tee-env-API_TOKEN_SECRET_NAME  = module.secret-manager.secret_versions[0]
     tee-env-CORE_BASE_URL          = var.uid_deployment_env == "integ" ? "https://core-integ.uidapi.com" : "https://core-prod.uidapi.com"


### PR DESCRIPTION
Currently, when debug mode is set, our validation process is unaware of it, and hence passes validation. However GCP attestation would fail when we are running debug in prod. 

Pass DEBUG_MODE to inside container to check and produce validation errors on start