### PR TITLE
Remove EXTRA_CONFIG build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ EXPOSE 8080
 ARG JAR_NAME=uid2-operator
 ARG JAR_VERSION=1.0.0-SNAPSHOT
 ARG IMAGE_VERSION=1.0.0.unknownhash
-ARG EXTRA_CONFIG
 ENV JAR_NAME=${JAR_NAME}
 ENV JAR_VERSION=${JAR_VERSION}
 ENV IMAGE_VERSION=${IMAGE_VERSION}
@@ -16,7 +15,7 @@ ENV REGION=us-east-2
 COPY ./target/${JAR_NAME}-${JAR_VERSION}-jar-with-dependencies.jar /app/${JAR_NAME}-${JAR_VERSION}.jar
 COPY ./target/${JAR_NAME}-${JAR_VERSION}-sources.jar /app
 COPY ./target/${JAR_NAME}-${JAR_VERSION}-static.tar.gz /app/static.tar.gz
-COPY ./conf/default-config.json ${EXTRA_CONFIG} /app/conf/
+COPY ./conf/default-config.json /app/conf/
 COPY ./conf/*.xml /app/conf/
 COPY ./conf/runtime-config-defaults.json /app/conf/
 COPY ./conf/feat-flag/feat-flag.json    /app/conf/feat-flag/

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.47.57</version>
+    <version>5.47.58-alpha-169-SNAPSHOT</version>
   
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This unused arg causes the entire build context to be copied to
/app/conf, including 1.7G of Trivy cache files.

|              | Before | After | Saving |
|--------------|--------|-------|--------|
| Compressed   | 2.1GB  | 216MB | 90%    |
| Uncompressed | 4.36GB | 371MB | 91%    |