### PR TITLE
xuy-UID2-4989-p-operator-e2es revert fix default urls

### DIFF
--- a/scripts/aws/EUID_CloudFormation.template.yml
+++ b/scripts/aws/EUID_CloudFormation.template.yml
@@ -162,9 +162,9 @@ Resources:
         - ''
         - - '{'
           - '"core_base_url": "'
-          - !If [IsIntegEnvironment, 'https://core-integ.uidapi.com', 'https://core.uidapi.com']
+          - !If [IsIntegEnvironment, 'https://core.integ.euid.eu', 'https://core.prod.euid.eu']
           - '", "optout_base_url": "'
-          - !If [IsIntegEnvironment, 'https://optout-integ.uidapi.com', 'https://optout.uidapi.com']
+          - !If [IsIntegEnvironment, 'https://optout.integ.euid.eu', 'https://optout.prod.euid.eu']
           - '", "operator_key": "'
           - Ref: APIToken
           - '"'


### PR DESCRIPTION
Revert default urls for euid

( bug introduced in https://github.com/IABTechLab/uid2-operator/pull/1504)