### PR TITLE
Enhanced E2E pipeline to better support real env testing #164

### DIFF
--- a/.github/workflows/run-e2e-tests-on-operator.yaml
+++ b/.github/workflows/run-e2e-tests-on-operator.yaml
@@ -117,7 +117,7 @@ on:
 jobs:
   e2e-test:
     name: E2E Test
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-run-e2e-tests.yaml@gdm-UID2-5050-e2e
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-run-e2e-tests.yaml@v3
     with:
       operator_type: ${{ inputs.operator_type }}
       identity_scope: ${{ inputs.identity_scope }}

--- a/.github/workflows/run-e2e-tests-on-operator.yaml
+++ b/.github/workflows/run-e2e-tests-on-operator.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       operator_type:
-        description: The operator type [public, gcp, azure, aws, eks, aks]
+        description: The operator type [public, gcp, azure, aws, aks]
         required: true
         type: choice
         options:
@@ -12,7 +12,6 @@ on:
           - gcp
           - azure
           - aws
-          - eks
           - aks
       identity_scope:
         description: The identity scope [UID2, EUID]
@@ -60,16 +59,11 @@ on:
           "region": "us-east-1",
           "ami": "ami-xxxxx",
           "pcr0": "xxxxx" }'
-      eks:
-        description: The arguments for EKS operator
-        type: string
-        default: '{
-          "pcr0": "xxxxx" }'
 
   workflow_call:
     inputs:
       operator_type:
-        description: The operator type [public, gcp, azure, aws, eks]
+        description: The operator type [public, gcp, azure, aws, aks]
         type: string
         default: public
       identity_scope:
@@ -110,11 +104,6 @@ on:
           "region": "us-east-1",
           "ami": "ami-xxxxx",
           "pcr0": "xxxxx" }'
-      eks:
-        description: The arguments for EKS operator
-        type: string
-        default: '{
-          "pcr0": "xxxxx" }'
 
 jobs:
   e2e-test:
@@ -138,7 +127,4 @@ jobs:
       aws_region: ${{ fromJson(inputs.aws).region }}
       aws_ami: ${{ fromJson(inputs.aws).ami }}
       aws_pcr0: ${{ fromJson(inputs.aws).pcr0 }}
-      eks_pcr0: ${{ fromJson(inputs.eks).pcr0 }}
-      eks_test_cluster: ${{ vars.EKS_TEST_CLUSTER }}
-      eks_test_cluster_region: ${{ vars.EKS_TEST_CLUSTER_REGION }}
     secrets: inherit

--- a/.github/workflows/run-e2e-tests-on-operator.yaml
+++ b/.github/workflows/run-e2e-tests-on-operator.yaml
@@ -111,7 +111,7 @@ jobs:
     uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-run-e2e-tests.yaml@gdm-UID2-5050-e2e
     with:
       operator_type: ${{ inputs.operator_type }}
-      uid2_e2e_identity_scope: ${{ inputs.identity_scope }}
+      identity_scope: ${{ inputs.identity_scope }}
       target_environment: ${{ inputs.target_environment }}
       operator_image_version: ${{ inputs.operator_image_version }}
       core_image_version: ${{ inputs.core_image_version }}

--- a/.github/workflows/run-e2e-tests-on-operator.yaml
+++ b/.github/workflows/run-e2e-tests-on-operator.yaml
@@ -1,5 +1,5 @@
 name: Run Operator E2E Tests
-run-name: ${{ format('Run Operator E2E Tests - {0} {1}', inputs.operator_type, inputs.identity_scope) }} by @${{ github.actor }}
+run-name: ${{ format('Run Operator E2E Tests - {0} {1} {2}', inputs.operator_type, inputs.identity_scope, inputs.target_environment) }} by @${{ github.actor }}
 on:
   workflow_dispatch:
     inputs:
@@ -20,6 +20,14 @@ on:
         options:
           - UID2
           - EUID
+      target_environment:
+        description: PRIVATE OPERATORS ONLY - The target environment [mock, integ, prod]
+        required: true
+        type: choice
+        options:
+          - mock
+          - integ
+          - prod
       operator_image_version:
         description: 'Image: Operator image version (for gcp/azure, set appropriate image)'
         type: string
@@ -67,6 +75,10 @@ on:
         description: The identity scope [UID2, EUID]
         type: string
         default: UID2
+      target_environment:
+        description: PRIVATE OPERATORS ONLY - The target environment [mock, integ, prod]
+        type: string
+        default: mock
       operator_image_version:
         description: 'Image: Operator image version (for gcp/azure, set appropriate image)'
         type: string
@@ -106,18 +118,19 @@ on:
 jobs:
   e2e-test:
     name: E2E Test
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-run-e2e-tests.yaml@v3
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-run-e2e-tests.yaml@gdm-UID2-5050-e2e
     with:
       operator_type: ${{ inputs.operator_type }}
+      uid2_e2e_identity_scope: ${{ inputs.identity_scope }}
+      target_environment: ${{ inputs.target_environment }}
       operator_image_version: ${{ inputs.operator_image_version }}
       core_image_version: ${{ inputs.core_image_version }}
       optout_image_version: ${{ inputs.optout_image_version }}
       e2e_image_version: ${{ inputs.e2e_image_version }}
       operator_branch: ${{ github.ref }}
-      branch_core: ${{ fromJson(inputs.branch).core }}
-      branch_optout: ${{ fromJson(inputs.branch).optout }}
-      branch_admin: ${{ fromJson(inputs.branch).admin }}
-      uid2_e2e_identity_scope: ${{ inputs.identity_scope }}
+      core_branch: ${{ fromJson(inputs.branch).core }}
+      optout_branch: ${{ fromJson(inputs.branch).optout }}
+      admin_branch: ${{ fromJson(inputs.branch).admin }}
       gcp_workload_identity_provider_id: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER_ID }}
       gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
       gcp_project: ${{ vars.GCP_PROJECT }}

--- a/.github/workflows/run-e2e-tests-on-operator.yaml
+++ b/.github/workflows/run-e2e-tests-on-operator.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       operator_type:
-        description: The operator type [public, gcp, azure, aws, eks]
+        description: The operator type [public, gcp, azure, aws, eks, aks]
         required: true
         type: choice
         options:
@@ -13,6 +13,7 @@ on:
           - azure
           - aws
           - eks
+          - aks
       identity_scope:
         description: The identity scope [UID2, EUID]
         required: true

--- a/.github/workflows/run-e2e-tests-on-operator.yaml
+++ b/.github/workflows/run-e2e-tests-on-operator.yaml
@@ -28,6 +28,11 @@ on:
           - mock
           - integ
           - prod
+      operator_shutdown:
+        description: PRIVATE OPERATORS ONLY - If true, will automatically shut down operators after E2E tests. If false, remember to manually clean up the operator.
+        required: true
+        type: boolean
+        default: true
       operator_image_version:
         description: 'Image: Operator image version (for gcp/azure, set appropriate image)'
         type: string
@@ -74,6 +79,10 @@ on:
         description: PRIVATE OPERATORS ONLY - The target environment [mock, integ, prod]
         type: string
         default: mock
+      operator_shutdown:
+        description: PRIVATE OPERATORS ONLY - If true, will automatically shut down operators after E2E tests. If false, remember to manually clean up the operator.
+        type: boolean
+        default: true
       operator_image_version:
         description: 'Image: Operator image version (for gcp/azure, set appropriate image)'
         type: string
@@ -113,6 +122,7 @@ jobs:
       operator_type: ${{ inputs.operator_type }}
       identity_scope: ${{ inputs.identity_scope }}
       target_environment: ${{ inputs.target_environment }}
+      operator_shutdown: ${{ inputs.operator_shutdown }}
       operator_image_version: ${{ inputs.operator_image_version }}
       core_image_version: ${{ inputs.core_image_version }}
       optout_image_version: ${{ inputs.optout_image_version }}

--- a/.trivyignore
+++ b/.trivyignore
@@ -9,8 +9,5 @@ CVE-2024-47535
 # https://thetradedesk.atlassian.net/browse/UID2-4874
 CVE-2025-24970
 
-# https://thetradedesk.atlassian.net/browse/UID2-4925
-CVE-2024-57699
-
 # https://thetradedesk.atlassian.net/browse/UID2-5186
 CVE-2024-8176 exp:2025-03-27


### PR DESCRIPTION
* Added `target_environment` input to distinguish between `mock`, `integ` and `prod` tests
  * `mock` tests retain current behaviour
  * `integ` and `prod` tests have additional logic to support real environment testing
    * HTTPS URLs, different operator keys, no need for Docker and bore
* Added `operator_shutdown` input to keep private operators running for extended manual testing