### PR TITLE
Add service instance ID and UID trace ID to core and opt out requests

### DIFF
--- a/conf/default-config.json
+++ b/conf/default-config.json
@@ -38,5 +38,6 @@
   "failure_shutdown_wait_hours": 120,
   "sharing_token_expiry_seconds": 2592000,
   "operator_type": "public",
-  "enable_remote_config": false
+  "enable_remote_config": false,
+  "uid_instance_id_prefix": "local-operator"
 }

--- a/conf/docker-config.json
+++ b/conf/docker-config.json
@@ -42,5 +42,6 @@
   "salts_expired_shutdown_hours": 12,
   "operator_type": "public",
   "disable_optout_token": true,
-  "enable_remote_config": false
+  "enable_remote_config": false,
+  "uid_instance_id_prefix": "local-operator"
 }

--- a/conf/integ-config.json
+++ b/conf/integ-config.json
@@ -18,5 +18,6 @@
   "salts_expired_shutdown_hours": 12,
   "operator_type": "public",
   "disable_optout_token": true,
-  "enable_remote_config": false
+  "enable_remote_config": false,
+  "uid_instance_id_prefix": "local-operator"
 }

--- a/conf/local-config.json
+++ b/conf/local-config.json
@@ -41,5 +41,6 @@
   "operator_type": "public",
   "encrypted_files": false,
   "disable_optout_token": true,
-  "enable_remote_config": false
+  "enable_remote_config": false,
+  "uid_instance_id_prefix": "local-operator"
 }

--- a/conf/local-e2e-docker-private-config.json
+++ b/conf/local-e2e-docker-private-config.json
@@ -31,5 +31,6 @@
   "cloud_refresh_interval": 30,
   "salts_expired_shutdown_hours": 12,
   "operator_type": "private",
-  "enable_remote_config": false
+  "enable_remote_config": false,
+  "uid_instance_id_prefix": "local-private-operator"
 }

--- a/conf/local-e2e-docker-public-config.json
+++ b/conf/local-e2e-docker-public-config.json
@@ -38,5 +38,6 @@
   "salts_expired_shutdown_hours": 12,
   "operator_type": "public",
   "disable_optout_token": true,
-  "enable_remote_config": false
+  "enable_remote_config": false,
+  "uid_instance_id_prefix": "local-public-operator"
 }

--- a/conf/local-e2e-private-config.json
+++ b/conf/local-e2e-private-config.json
@@ -42,5 +42,6 @@
   "client_side_token_generate_log_invalid_http_origins": true,
   "salts_expired_shutdown_hours": 12,
   "operator_type": "private",
-  "enable_remote_config": false
+  "enable_remote_config": false,
+  "uid_instance_id_prefix": "local-private-operator"
 }

--- a/conf/local-e2e-public-config.json
+++ b/conf/local-e2e-public-config.json
@@ -44,5 +44,6 @@
   "salts_expired_shutdown_hours": 12,
   "operator_type": "public",
   "disable_optout_token": true,
-  "enable_remote_config": false
+  "enable_remote_config": false,
+  "uid_instance_id_prefix": "local-public-operator"
 }

--- a/conf/validator-latest-e2e-docker-public-config.json
+++ b/conf/validator-latest-e2e-docker-public-config.json
@@ -43,5 +43,6 @@
     "config_scan_period_ms": 300000
   },
   "disable_optout_token": true,
-  "enable_remote_config": false
+  "enable_remote_config": false,
+  "uid_instance_id_prefix": "local-public-operator"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,12 @@
             <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.uid2</groupId>
+            <artifactId>uid2-shared</artifactId>
+            <version>9.5.3</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,12 @@
             <version>9.5.3</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.uid2</groupId>
+            <artifactId>uid2-shared</artifactId>
+            <version>9.5.4-alpha-236-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -210,12 +210,6 @@
         <dependency>
             <groupId>com.uid2</groupId>
             <artifactId>uid2-shared</artifactId>
-            <version>9.5.3</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.uid2</groupId>
-            <artifactId>uid2-shared</artifactId>
             <version>9.5.4-alpha-236-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <enclave-aws.version>2.1.0</enclave-aws.version>
         <enclave-azure.version>2.1.13</enclave-azure.version>
         <enclave-gcp.version>2.1.0</enclave-gcp.version>
-        <uid2-shared.version>9.4.14</uid2-shared.version>
+        <uid2-shared.version>10.0.0</uid2-shared.version>
         <image.version>${project.version}</image.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
@@ -206,12 +206,6 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>5.12.0</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.uid2</groupId>
-            <artifactId>uid2-shared</artifactId>
-            <version>9.5.4-alpha-236-SNAPSHOT</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/uid2/operator/Main.java
+++ b/src/main/java/com/uid2/operator/Main.java
@@ -18,7 +18,7 @@ import com.uid2.operator.vertx.UIDOperatorVerticle;
 import com.uid2.shared.ApplicationVersion;
 import com.uid2.shared.Utils;
 import com.uid2.shared.attest.*;
-import com.uid2.shared.audit.ServiceInstanceIdProvider;
+import com.uid2.shared.audit.UidInstanceIdProvider;
 import com.uid2.shared.cloud.*;
 import com.uid2.shared.jmx.AdminApi;
 import com.uid2.shared.optout.OptOutCloudSync;
@@ -91,7 +91,7 @@ public class Main {
     private RotatingServiceStore serviceProvider;
     private RotatingServiceLinkStore serviceLinkProvider;
     private RotatingCloudEncryptionKeyApiProvider cloudEncryptionKeyProvider;
-    private final ServiceInstanceIdProvider serviceInstanceIdProvider;
+    private final UidInstanceIdProvider uidInstanceIdProvider;
 
     public Main(Vertx vertx, JsonObject config) throws Exception {
         this.vertx = vertx;
@@ -113,7 +113,7 @@ public class Main {
         this.validateServiceLinks = config.getBoolean(Const.Config.ValidateServiceLinks, false);
         this.encryptedCloudFilesEnabled = config.getBoolean(Const.Config.EncryptedFiles, false);
         this.shutdownHandler = new OperatorShutdownHandler(Duration.ofHours(12), Duration.ofHours(config.getInteger(Const.Config.SaltsExpiredShutdownHours, 12)), Clock.systemUTC(), new ShutdownService());
-        this.serviceInstanceIdProvider = new ServiceInstanceIdProvider(config);
+        this.uidInstanceIdProvider = new UidInstanceIdProvider(config);
 
         String coreAttestUrl = this.config.getString(Const.Config.CoreAttestUrlProp);
 
@@ -328,7 +328,7 @@ public class Main {
         this.createVertxEventLoopsMetric();
 
         Supplier<Verticle> operatorVerticleSupplier = () -> {
-            UIDOperatorVerticle verticle = new UIDOperatorVerticle(configStore, config, this.clientSideTokenGenerate, siteProvider, clientKeyProvider, clientSideKeypairProvider, getKeyManager(), saltProvider, optOutStore, Clock.systemUTC(), _statsCollectorQueue, new SecureLinkValidatorService(this.serviceLinkProvider, this.serviceProvider), this.shutdownHandler::handleSaltRetrievalResponse, this.serviceInstanceIdProvider);
+            UIDOperatorVerticle verticle = new UIDOperatorVerticle(configStore, config, this.clientSideTokenGenerate, siteProvider, clientKeyProvider, clientSideKeypairProvider, getKeyManager(), saltProvider, optOutStore, Clock.systemUTC(), _statsCollectorQueue, new SecureLinkValidatorService(this.serviceLinkProvider, this.serviceProvider), this.shutdownHandler::handleSaltRetrievalResponse, this.uidInstanceIdProvider);
             return verticle;
         };
 
@@ -547,8 +547,8 @@ public class Main {
 
     private Map.Entry<UidCoreClient, UidOptOutClient> createUidClients(Vertx vertx, String attestationUrl, String clientApiToken, Handler<Pair<AttestationResponseCode, String>> responseWatcher) throws Exception {
         AttestationResponseHandler attestationResponseHandler = getAttestationTokenRetriever(vertx, attestationUrl, clientApiToken, responseWatcher);
-        UidCoreClient coreClient = new UidCoreClient(clientApiToken, CloudUtils.defaultProxy, attestationResponseHandler, this.encryptedCloudFilesEnabled, this.serviceInstanceIdProvider);
-        UidOptOutClient optOutClient = new UidOptOutClient(clientApiToken, CloudUtils.defaultProxy, attestationResponseHandler, this.serviceInstanceIdProvider);
+        UidCoreClient coreClient = new UidCoreClient(clientApiToken, CloudUtils.defaultProxy, attestationResponseHandler, this.encryptedCloudFilesEnabled, this.uidInstanceIdProvider);
+        UidOptOutClient optOutClient = new UidOptOutClient(clientApiToken, CloudUtils.defaultProxy, attestationResponseHandler, this.uidInstanceIdProvider);
         return new AbstractMap.SimpleEntry<>(coreClient, optOutClient);
     }
 

--- a/src/main/java/com/uid2/operator/Main.java
+++ b/src/main/java/com/uid2/operator/Main.java
@@ -584,7 +584,7 @@ public class Main {
                 throw new IllegalArgumentException(String.format("enclave_platform is providing the wrong value: %s", enclavePlatform));
         }
 
-        return new AttestationResponseHandler(vertx, attestationUrl, clientApiToken, operatorType, this.appVersion, attestationProvider, responseWatcher, CloudUtils.defaultProxy);
+        return new AttestationResponseHandler(vertx, attestationUrl, clientApiToken, operatorType, this.appVersion, attestationProvider, responseWatcher, CloudUtils.defaultProxy, this.uidInstanceIdProvider);
     }
 
     private IOperatorKeyRetriever createOperatorKeyRetriever() throws Exception {

--- a/src/main/java/com/uid2/operator/service/IUIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/IUIDOperatorService.java
@@ -22,7 +22,7 @@ public interface IUIDOperatorService {
 
     List<SaltEntry> getModifiedBuckets(Instant sinceTimestamp);
 
-    void invalidateTokensAsync(UserIdentity userIdentity, Instant asOf, Handler<AsyncResult<Instant>> handler);
+    void invalidateTokensAsync(UserIdentity userIdentity, Instant asOf, String uidTraceId, Handler<AsyncResult<Instant>> handler);
 
     boolean advertisingTokenMatches(String advertisingToken, UserIdentity userIdentity, Instant asOf);
 

--- a/src/main/java/com/uid2/operator/service/UIDOperatorService.java
+++ b/src/main/java/com/uid2/operator/service/UIDOperatorService.java
@@ -2,7 +2,7 @@ package com.uid2.operator.service;
 
 import com.uid2.operator.model.*;
 import com.uid2.operator.util.PrivacyBits;
-import com.uid2.shared.audit.ServiceInstanceIdProvider;
+import com.uid2.shared.audit.UidInstanceIdProvider;
 import com.uid2.shared.model.SaltEntry;
 import com.uid2.operator.store.IOptOutStore;
 import com.uid2.shared.store.salt.ISaltProvider;
@@ -51,17 +51,17 @@ public class UIDOperatorService implements IUIDOperatorService {
     private final boolean rawUidV3Enabled;
 
     private final Handler<Boolean> saltRetrievalResponseHandler;
-    private final ServiceInstanceIdProvider serviceInstanceIdProvider;
+    private final UidInstanceIdProvider uidInstanceIdProvider;
 
     public UIDOperatorService(IOptOutStore optOutStore, ISaltProvider saltProvider, ITokenEncoder encoder, Clock clock,
-                              IdentityScope identityScope, Handler<Boolean> saltRetrievalResponseHandler, boolean identityV3Enabled, ServiceInstanceIdProvider serviceInstanceIdProvider) {
+                              IdentityScope identityScope, Handler<Boolean> saltRetrievalResponseHandler, boolean identityV3Enabled, UidInstanceIdProvider uidInstanceIdProvider) {
         this.saltProvider = saltProvider;
         this.encoder = encoder;
         this.optOutStore = optOutStore;
         this.clock = clock;
         this.identityScope = identityScope;
         this.saltRetrievalResponseHandler = saltRetrievalResponseHandler;
-        this.serviceInstanceIdProvider = serviceInstanceIdProvider;
+        this.uidInstanceIdProvider = uidInstanceIdProvider;
 
         this.testOptOutIdentityForEmail = getFirstLevelHashIdentity(identityScope, IdentityType.Email,
                 InputUtil.normalizeEmail(OptOutIdentityForEmail).getIdentityInput(), Instant.now());
@@ -187,7 +187,7 @@ public class UIDOperatorService implements IUIDOperatorService {
         final UserIdentity firstLevelHashIdentity = getFirstLevelHashIdentity(userIdentity, asOf);
         final MappedIdentity mappedIdentity = getMappedIdentity(firstLevelHashIdentity, asOf);
 
-        this.optOutStore.addEntry(firstLevelHashIdentity, mappedIdentity.advertisingId, uidTraceId, this.serviceInstanceIdProvider.getInstanceId(), r -> {
+        this.optOutStore.addEntry(firstLevelHashIdentity, mappedIdentity.advertisingId, uidTraceId, this.uidInstanceIdProvider.getInstanceId(), r -> {
             if (r.succeeded()) {
                 handler.handle(Future.succeededFuture(r.result()));
             } else {

--- a/src/main/java/com/uid2/operator/store/CloudSyncOptOutStore.java
+++ b/src/main/java/com/uid2/operator/store/CloudSyncOptOutStore.java
@@ -88,7 +88,7 @@ public class CloudSyncOptOutStore implements IOptOutStore {
     }
 
     @Override
-    public void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, String uidTraceId, String serviceInstanceId, Handler<AsyncResult<Instant>> handler) {
+    public void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, String uidTraceId, String uidInstanceId, Handler<AsyncResult<Instant>> handler) {
         if (remoteApiHost == null) {
             handler.handle(Future.failedFuture("remote api not set"));
             return;
@@ -98,7 +98,7 @@ public class CloudSyncOptOutStore implements IOptOutStore {
             addQueryParam("identity_hash", EncodingUtils.toBase64String(firstLevelHashIdentity.id))
             .addQueryParam("advertising_id", EncodingUtils.toBase64String(advertisingId))
             .putHeader("Authorization", remoteApiBearerToken)
-            .putHeader(Audit.UID_INSTANCE_ID_HEADER, serviceInstanceId)
+            .putHeader(Audit.UID_INSTANCE_ID_HEADER, uidInstanceId)
             .as(BodyCodec.string());
 
         if (uidTraceId != null) {

--- a/src/main/java/com/uid2/operator/store/CloudSyncOptOutStore.java
+++ b/src/main/java/com/uid2/operator/store/CloudSyncOptOutStore.java
@@ -7,6 +7,7 @@ import com.uid2.operator.Const;
 import com.uid2.operator.model.UserIdentity;
 import com.uid2.operator.service.EncodingUtils;
 import com.uid2.shared.Utils;
+import com.uid2.shared.audit.Audit;
 import com.uid2.shared.cloud.CloudStorageException;
 import com.uid2.shared.cloud.DownloadCloudStorage;
 import com.uid2.shared.cloud.ICloudStorage;
@@ -19,6 +20,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.codec.BodyCodec;
@@ -86,32 +88,38 @@ public class CloudSyncOptOutStore implements IOptOutStore {
     }
 
     @Override
-    public void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, Handler<AsyncResult<Instant>> handler) {
+    public void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, String uidTraceId, String serviceInstanceId, Handler<AsyncResult<Instant>> handler) {
         if (remoteApiHost == null) {
             handler.handle(Future.failedFuture("remote api not set"));
             return;
         }
 
-        this.webClient.get(remoteApiPort, remoteApiHost, remoteApiPath).
+        HttpRequest<String> request =this.webClient.get(remoteApiPort, remoteApiHost, remoteApiPath).
             addQueryParam("identity_hash", EncodingUtils.toBase64String(firstLevelHashIdentity.id))
             .addQueryParam("advertising_id", EncodingUtils.toBase64String(advertisingId))
             .putHeader("Authorization", remoteApiBearerToken)
-            .as(BodyCodec.string())
-            .send(ar -> {
-                Exception failure = null;
-                if (ar.failed()) {
-                    failure = new Exception(ar.cause());
-                } else if (ar.result().statusCode() != 200) {
-                    failure = new Exception("optout api http status: " + String.valueOf(ar.result().statusCode()));
-                }
+            .putHeader(Audit.UID_INSTANCE_ID_HEADER, serviceInstanceId)
+            .as(BodyCodec.string());
 
-                if (failure == null) {
-                    handler.handle(Future.succeededFuture(Utils.nowUTCMillis()));
-                } else {
-                    LOGGER.error("CloudSyncOptOutStore.addEntry remote web request failed", failure);
-                    handler.handle(Future.failedFuture(failure));
-                }
-            });
+        if (uidTraceId != null) {
+            request = request.putHeader(Audit.UID_TRACE_ID_HEADER, uidTraceId);
+        }
+
+        request.send(ar -> {
+            Exception failure = null;
+            if (ar.failed()) {
+                failure = new Exception(ar.cause());
+            } else if (ar.result().statusCode() != 200) {
+                failure = new Exception("optout api http status: " + String.valueOf(ar.result().statusCode()));
+            }
+
+            if (failure == null) {
+                handler.handle(Future.succeededFuture(Utils.nowUTCMillis()));
+            } else {
+                LOGGER.error("CloudSyncOptOutStore.addEntry remote web request failed", failure);
+                handler.handle(Future.failedFuture(failure));
+            }
+        });
     }
 
     public void registerCloudSync(OptOutCloudSync cloudSync) {

--- a/src/main/java/com/uid2/operator/store/IOptOutStore.java
+++ b/src/main/java/com/uid2/operator/store/IOptOutStore.java
@@ -17,5 +17,5 @@ public interface IOptOutStore {
 
     long getOptOutTimestampByAdId(String adId);
 
-    void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, Handler<AsyncResult<Instant>> handler);
+    void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, String uidTraceId, String serviceInstanceId, Handler<AsyncResult<Instant>> handler);
 }

--- a/src/main/java/com/uid2/operator/store/IOptOutStore.java
+++ b/src/main/java/com/uid2/operator/store/IOptOutStore.java
@@ -17,5 +17,5 @@ public interface IOptOutStore {
 
     long getOptOutTimestampByAdId(String adId);
 
-    void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, String uidTraceId, String serviceInstanceId, Handler<AsyncResult<Instant>> handler);
+    void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, String uidTraceId, String uidInstanceId, Handler<AsyncResult<Instant>> handler);
 }

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -22,7 +22,7 @@ import com.uid2.operator.util.Tuple;
 import com.uid2.shared.Const.Data;
 import com.uid2.shared.Utils;
 import com.uid2.shared.audit.Audit;
-import com.uid2.shared.audit.ServiceInstanceIdProvider;
+import com.uid2.shared.audit.UidInstanceIdProvider;
 import com.uid2.shared.auth.*;
 import com.uid2.shared.encryption.AesGcm;
 import com.uid2.shared.health.HealthComponent;
@@ -107,7 +107,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
     private final boolean allowLegacyAPI;
     private final boolean identityV3Enabled;
     private final boolean disableOptoutToken;
-    private final ServiceInstanceIdProvider serviceInstanceIdProvider;
+    private final UidInstanceIdProvider uidInstanceIdProvider;
     protected IUIDOperatorService idService;
     private final Map<String, DistributionSummary> _identityMapMetricSummaries = new HashMap<>();
     private final Map<Tuple.Tuple2<String, Boolean>, DistributionSummary> _refreshDurationMetricSummaries = new HashMap<>();
@@ -165,7 +165,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                                IStatsCollectorQueue statsCollectorQueue,
                                SecureLinkValidatorService secureLinkValidatorService,
                                Handler<Boolean> saltRetrievalResponseHandler,
-                               ServiceInstanceIdProvider serviceInstanceIdProvider) {
+                               UidInstanceIdProvider uidInstanceIdProvider) {
         this.keyManager = keyManager;
         this.secureLinkValidatorService = secureLinkValidatorService;
         try {
@@ -199,7 +199,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
         this.allowLegacyAPI = config.getBoolean(Const.Config.AllowLegacyAPIProp, false);
         this.identityV3Enabled = config.getBoolean(IdentityV3Prop, false);
         this.disableOptoutToken = config.getBoolean(DisableOptoutTokenProp, false);
-        this.serviceInstanceIdProvider = serviceInstanceIdProvider;
+        this.uidInstanceIdProvider = uidInstanceIdProvider;
     }
 
     @Override
@@ -213,7 +213,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                 this.identityScope,
                 this.saltRetrievalResponseHandler,
                 this.identityV3Enabled,
-                this.serviceInstanceIdProvider
+                this.uidInstanceIdProvider
         );
 
         final Router router = createRoutesSetup();

--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -21,6 +21,8 @@ import com.uid2.operator.util.RoutingContextUtil;
 import com.uid2.operator.util.Tuple;
 import com.uid2.shared.Const.Data;
 import com.uid2.shared.Utils;
+import com.uid2.shared.audit.Audit;
+import com.uid2.shared.audit.ServiceInstanceIdProvider;
 import com.uid2.shared.auth.*;
 import com.uid2.shared.encryption.AesGcm;
 import com.uid2.shared.health.HealthComponent;
@@ -105,6 +107,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
     private final boolean allowLegacyAPI;
     private final boolean identityV3Enabled;
     private final boolean disableOptoutToken;
+    private final ServiceInstanceIdProvider serviceInstanceIdProvider;
     protected IUIDOperatorService idService;
     private final Map<String, DistributionSummary> _identityMapMetricSummaries = new HashMap<>();
     private final Map<Tuple.Tuple2<String, Boolean>, DistributionSummary> _refreshDurationMetricSummaries = new HashMap<>();
@@ -161,7 +164,8 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                                Clock clock,
                                IStatsCollectorQueue statsCollectorQueue,
                                SecureLinkValidatorService secureLinkValidatorService,
-                               Handler<Boolean> saltRetrievalResponseHandler) {
+                               Handler<Boolean> saltRetrievalResponseHandler,
+                               ServiceInstanceIdProvider serviceInstanceIdProvider) {
         this.keyManager = keyManager;
         this.secureLinkValidatorService = secureLinkValidatorService;
         try {
@@ -195,6 +199,7 @@ public class UIDOperatorVerticle extends AbstractVerticle {
         this.allowLegacyAPI = config.getBoolean(Const.Config.AllowLegacyAPIProp, false);
         this.identityV3Enabled = config.getBoolean(IdentityV3Prop, false);
         this.disableOptoutToken = config.getBoolean(DisableOptoutTokenProp, false);
+        this.serviceInstanceIdProvider = serviceInstanceIdProvider;
     }
 
     @Override
@@ -207,7 +212,8 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                 this.clock,
                 this.identityScope,
                 this.saltRetrievalResponseHandler,
-                this.identityV3Enabled
+                this.identityV3Enabled,
+                this.serviceInstanceIdProvider
         );
 
         final Router router = createRoutesSetup();
@@ -1214,9 +1220,10 @@ public class UIDOperatorVerticle extends AbstractVerticle {
 
     private void handleLogoutAsync(RoutingContext rc) {
         final InputUtil.InputVal input = this.phoneSupport ? getTokenInputV1(rc) : getTokenInput(rc);
+        final String uidTraceId = rc.request().getHeader(Audit.UID_TRACE_ID_HEADER);
         if (input.isValid()) {
             final Instant now = Instant.now();
-            this.idService.invalidateTokensAsync(input.toUserIdentity(this.identityScope, 0, now), now, ar -> {
+            this.idService.invalidateTokensAsync(input.toUserIdentity(this.identityScope, 0, now), now, uidTraceId, ar -> {
                 if (ar.succeeded()) {
                     rc.response().end("OK");
                 } else {
@@ -1231,11 +1238,12 @@ public class UIDOperatorVerticle extends AbstractVerticle {
     private Future handleLogoutAsyncV2(RoutingContext rc) {
         final JsonObject req = (JsonObject) rc.data().get("request");
         final InputUtil.InputVal input = getTokenInputV2(req);
+        final String uidTraceId = rc.request().getHeader(Audit.UID_TRACE_ID_HEADER);
         if (input.isValid()) {
             final Instant now = Instant.now();
 
             Promise promise = Promise.promise();
-            this.idService.invalidateTokensAsync(input.toUserIdentity(this.identityScope, 0, now), now, ar -> {
+            this.idService.invalidateTokensAsync(input.toUserIdentity(this.identityScope, 0, now), now, uidTraceId, ar -> {
                 if (ar.succeeded()) {
                     JsonObject body = new JsonObject();
                     body.put("optout", "OK");

--- a/src/test/java/com/uid2/operator/ExtendedUIDOperatorVerticle.java
+++ b/src/test/java/com/uid2/operator/ExtendedUIDOperatorVerticle.java
@@ -7,6 +7,7 @@ import com.uid2.operator.service.SecureLinkValidatorService;
 import com.uid2.operator.store.IConfigStore;
 import com.uid2.operator.store.IOptOutStore;
 import com.uid2.operator.vertx.UIDOperatorVerticle;
+import com.uid2.shared.audit.ServiceInstanceIdProvider;
 import com.uid2.shared.store.*;
 import com.uid2.shared.store.salt.ISaltProvider;
 import io.vertx.core.Handler;
@@ -31,8 +32,9 @@ public class ExtendedUIDOperatorVerticle extends UIDOperatorVerticle {
                                        Clock clock,
                                        IStatsCollectorQueue statsCollectorQueue,
                                        SecureLinkValidatorService secureLinkValidationService,
-                                       Handler<Boolean> saltRetrievalResponseHandler) {
-        super(configStore, config, clientSideTokenGenerate, siteProvider, clientKeyProvider, clientSideKeypairProvider, keyManager, saltProvider, optOutStore, clock, statsCollectorQueue, secureLinkValidationService, saltRetrievalResponseHandler);
+                                       Handler<Boolean> saltRetrievalResponseHandler,
+                                       ServiceInstanceIdProvider serviceInstanceIdProvider) {
+        super(configStore, config, clientSideTokenGenerate, siteProvider, clientKeyProvider, clientSideKeypairProvider, keyManager, saltProvider, optOutStore, clock, statsCollectorQueue, secureLinkValidationService, saltRetrievalResponseHandler, serviceInstanceIdProvider);
     }
 
     public IUIDOperatorService getIdService() {

--- a/src/test/java/com/uid2/operator/ExtendedUIDOperatorVerticle.java
+++ b/src/test/java/com/uid2/operator/ExtendedUIDOperatorVerticle.java
@@ -7,7 +7,7 @@ import com.uid2.operator.service.SecureLinkValidatorService;
 import com.uid2.operator.store.IConfigStore;
 import com.uid2.operator.store.IOptOutStore;
 import com.uid2.operator.vertx.UIDOperatorVerticle;
-import com.uid2.shared.audit.ServiceInstanceIdProvider;
+import com.uid2.shared.audit.UidInstanceIdProvider;
 import com.uid2.shared.store.*;
 import com.uid2.shared.store.salt.ISaltProvider;
 import io.vertx.core.Handler;
@@ -33,8 +33,8 @@ public class ExtendedUIDOperatorVerticle extends UIDOperatorVerticle {
                                        IStatsCollectorQueue statsCollectorQueue,
                                        SecureLinkValidatorService secureLinkValidationService,
                                        Handler<Boolean> saltRetrievalResponseHandler,
-                                       ServiceInstanceIdProvider serviceInstanceIdProvider) {
-        super(configStore, config, clientSideTokenGenerate, siteProvider, clientKeyProvider, clientSideKeypairProvider, keyManager, saltProvider, optOutStore, clock, statsCollectorQueue, secureLinkValidationService, saltRetrievalResponseHandler, serviceInstanceIdProvider);
+                                       UidInstanceIdProvider uidInstanceIdProvider) {
+        super(configStore, config, clientSideTokenGenerate, siteProvider, clientKeyProvider, clientSideKeypairProvider, keyManager, saltProvider, optOutStore, clock, statsCollectorQueue, secureLinkValidationService, saltRetrievalResponseHandler, uidInstanceIdProvider);
     }
 
     public IUIDOperatorService getIdService() {

--- a/src/test/java/com/uid2/operator/UIDOperatorServiceTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorServiceTest.java
@@ -8,6 +8,7 @@ import com.uid2.operator.service.InputUtil;
 import com.uid2.operator.service.UIDOperatorService;
 import com.uid2.operator.store.IOptOutStore;
 import com.uid2.operator.vertx.OperatorShutdownHandler;
+import com.uid2.shared.audit.ServiceInstanceIdProvider;
 import com.uid2.shared.model.SaltEntry;
 import com.uid2.shared.store.CloudPath;
 import com.uid2.shared.store.salt.ISaltProvider;
@@ -47,6 +48,7 @@ public class UIDOperatorServiceTest {
     @Mock private Clock clock;
     @Mock private OperatorShutdownHandler shutdownHandler;
     EncryptedTokenEncoder tokenEncoder;
+    ServiceInstanceIdProvider serviceInstanceIdProvider;
     JsonObject uid2Config;
     JsonObject euidConfig;
     ExtendedUIDOperatorService uid2Service;
@@ -60,8 +62,8 @@ public class UIDOperatorServiceTest {
     final String FIRST_LEVEL_SALT = "first-level-salt";
 
     class ExtendedUIDOperatorService extends UIDOperatorService {
-        public ExtendedUIDOperatorService(IOptOutStore optOutStore, ISaltProvider saltProvider, ITokenEncoder encoder, Clock clock, IdentityScope identityScope, Handler<Boolean> saltRetrievalResponseHandler, boolean identityV3Enabled) {
-            super(optOutStore, saltProvider, encoder, clock, identityScope, saltRetrievalResponseHandler, identityV3Enabled);
+        public ExtendedUIDOperatorService(IOptOutStore optOutStore, ISaltProvider saltProvider, ITokenEncoder encoder, Clock clock, IdentityScope identityScope, Handler<Boolean> saltRetrievalResponseHandler, boolean identityV3Enabled, ServiceInstanceIdProvider serviceInstanceIdProvider) {
+            super(optOutStore, saltProvider, encoder, clock, identityScope, saltRetrievalResponseHandler, identityV3Enabled, serviceInstanceIdProvider);
         }
     }
 
@@ -96,6 +98,8 @@ public class UIDOperatorServiceTest {
         uid2Config.put(UIDOperatorService.REFRESH_IDENTITY_TOKEN_AFTER_SECONDS, REFRESH_IDENTITY_TOKEN_AFTER_SECONDS);
         uid2Config.put(IdentityV3Prop, false);
 
+        serviceInstanceIdProvider = new ServiceInstanceIdProvider("test-instance", "id");
+
         uid2Service = new ExtendedUIDOperatorService(
                 optOutStore,
                 saltProvider,
@@ -103,7 +107,8 @@ public class UIDOperatorServiceTest {
                 this.clock,
                 IdentityScope.UID2,
                 this.shutdownHandler::handleSaltRetrievalResponse,
-                uid2Config.getBoolean(IdentityV3Prop)
+                uid2Config.getBoolean(IdentityV3Prop),
+                serviceInstanceIdProvider
         );
 
         euidConfig = new JsonObject();
@@ -119,7 +124,8 @@ public class UIDOperatorServiceTest {
                 this.clock,
                 IdentityScope.EUID,
                 this.shutdownHandler::handleSaltRetrievalResponse,
-                euidConfig.getBoolean(IdentityV3Prop)
+                euidConfig.getBoolean(IdentityV3Prop),
+                serviceInstanceIdProvider
         );
     }
 
@@ -147,7 +153,8 @@ public class UIDOperatorServiceTest {
                 this.clock,
                 IdentityScope.UID2,
                 this.shutdownHandler::handleSaltRetrievalResponse,
-                uid2Config.getBoolean(IdentityV3Prop)
+                uid2Config.getBoolean(IdentityV3Prop),
+                serviceInstanceIdProvider
         );
 
         return saltSnapshot;
@@ -806,7 +813,8 @@ public class UIDOperatorServiceTest {
                 this.clock,
                 IdentityScope.UID2,
                 this.shutdownHandler::handleSaltRetrievalResponse,
-                uid2Config.getBoolean(IdentityV3Prop)
+                uid2Config.getBoolean(IdentityV3Prop),
+                serviceInstanceIdProvider
         );
 
         UIDOperatorService euidService = new UIDOperatorService(
@@ -816,7 +824,8 @@ public class UIDOperatorServiceTest {
                 this.clock,
                 IdentityScope.EUID,
                 this.shutdownHandler::handleSaltRetrievalResponse,
-                euidConfig.getBoolean(IdentityV3Prop)
+                euidConfig.getBoolean(IdentityV3Prop),
+                serviceInstanceIdProvider
         );
 
         when(this.optOutStore.getLatestEntry(any())).thenReturn(null);

--- a/src/test/java/com/uid2/operator/UIDOperatorServiceTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorServiceTest.java
@@ -8,7 +8,7 @@ import com.uid2.operator.service.InputUtil;
 import com.uid2.operator.service.UIDOperatorService;
 import com.uid2.operator.store.IOptOutStore;
 import com.uid2.operator.vertx.OperatorShutdownHandler;
-import com.uid2.shared.audit.ServiceInstanceIdProvider;
+import com.uid2.shared.audit.UidInstanceIdProvider;
 import com.uid2.shared.model.SaltEntry;
 import com.uid2.shared.store.CloudPath;
 import com.uid2.shared.store.salt.ISaltProvider;
@@ -48,7 +48,7 @@ public class UIDOperatorServiceTest {
     @Mock private Clock clock;
     @Mock private OperatorShutdownHandler shutdownHandler;
     EncryptedTokenEncoder tokenEncoder;
-    ServiceInstanceIdProvider serviceInstanceIdProvider;
+    UidInstanceIdProvider uidInstanceIdProvider;
     JsonObject uid2Config;
     JsonObject euidConfig;
     ExtendedUIDOperatorService uid2Service;
@@ -62,8 +62,8 @@ public class UIDOperatorServiceTest {
     final String FIRST_LEVEL_SALT = "first-level-salt";
 
     class ExtendedUIDOperatorService extends UIDOperatorService {
-        public ExtendedUIDOperatorService(IOptOutStore optOutStore, ISaltProvider saltProvider, ITokenEncoder encoder, Clock clock, IdentityScope identityScope, Handler<Boolean> saltRetrievalResponseHandler, boolean identityV3Enabled, ServiceInstanceIdProvider serviceInstanceIdProvider) {
-            super(optOutStore, saltProvider, encoder, clock, identityScope, saltRetrievalResponseHandler, identityV3Enabled, serviceInstanceIdProvider);
+        public ExtendedUIDOperatorService(IOptOutStore optOutStore, ISaltProvider saltProvider, ITokenEncoder encoder, Clock clock, IdentityScope identityScope, Handler<Boolean> saltRetrievalResponseHandler, boolean identityV3Enabled, UidInstanceIdProvider uidInstanceIdProvider) {
+            super(optOutStore, saltProvider, encoder, clock, identityScope, saltRetrievalResponseHandler, identityV3Enabled, uidInstanceIdProvider);
         }
     }
 
@@ -98,7 +98,7 @@ public class UIDOperatorServiceTest {
         uid2Config.put(UIDOperatorService.REFRESH_IDENTITY_TOKEN_AFTER_SECONDS, REFRESH_IDENTITY_TOKEN_AFTER_SECONDS);
         uid2Config.put(IdentityV3Prop, false);
 
-        serviceInstanceIdProvider = new ServiceInstanceIdProvider("test-instance", "id");
+        uidInstanceIdProvider = new UidInstanceIdProvider("test-instance", "id");
 
         uid2Service = new ExtendedUIDOperatorService(
                 optOutStore,
@@ -108,7 +108,7 @@ public class UIDOperatorServiceTest {
                 IdentityScope.UID2,
                 this.shutdownHandler::handleSaltRetrievalResponse,
                 uid2Config.getBoolean(IdentityV3Prop),
-                serviceInstanceIdProvider
+                uidInstanceIdProvider
         );
 
         euidConfig = new JsonObject();
@@ -125,7 +125,7 @@ public class UIDOperatorServiceTest {
                 IdentityScope.EUID,
                 this.shutdownHandler::handleSaltRetrievalResponse,
                 euidConfig.getBoolean(IdentityV3Prop),
-                serviceInstanceIdProvider
+                uidInstanceIdProvider
         );
     }
 
@@ -154,7 +154,7 @@ public class UIDOperatorServiceTest {
                 IdentityScope.UID2,
                 this.shutdownHandler::handleSaltRetrievalResponse,
                 uid2Config.getBoolean(IdentityV3Prop),
-                serviceInstanceIdProvider
+                uidInstanceIdProvider
         );
 
         return saltSnapshot;
@@ -814,7 +814,7 @@ public class UIDOperatorServiceTest {
                 IdentityScope.UID2,
                 this.shutdownHandler::handleSaltRetrievalResponse,
                 uid2Config.getBoolean(IdentityV3Prop),
-                serviceInstanceIdProvider
+                uidInstanceIdProvider
         );
 
         UIDOperatorService euidService = new UIDOperatorService(
@@ -825,7 +825,7 @@ public class UIDOperatorServiceTest {
                 IdentityScope.EUID,
                 this.shutdownHandler::handleSaltRetrievalResponse,
                 euidConfig.getBoolean(IdentityV3Prop),
-                serviceInstanceIdProvider
+                uidInstanceIdProvider
         );
 
         when(this.optOutStore.getLatestEntry(any())).thenReturn(null);

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -16,7 +16,7 @@ import com.uid2.operator.util.Tuple;
 import com.uid2.operator.vertx.OperatorShutdownHandler;
 import com.uid2.operator.vertx.UIDOperatorVerticle;
 import com.uid2.shared.Utils;
-import com.uid2.shared.audit.ServiceInstanceIdProvider;
+import com.uid2.shared.audit.UidInstanceIdProvider;
 import com.uid2.shared.auth.ClientKey;
 import com.uid2.shared.auth.Keyset;
 import com.uid2.shared.auth.KeysetSnapshot;
@@ -132,7 +132,7 @@ public class UIDOperatorVerticleTest {
     private OperatorShutdownHandler shutdownHandler;
     @Mock
     private IConfigStore configStore;
-    private ServiceInstanceIdProvider serviceInstanceIdProvider;
+    private UidInstanceIdProvider uidInstanceIdProvider;
 
     private SimpleMeterRegistry registry;
     private ExtendedUIDOperatorVerticle uidOperatorVerticle;
@@ -161,9 +161,9 @@ public class UIDOperatorVerticleTest {
         config.put("allow_legacy_api", true);
         when(configStore.getConfig()).thenAnswer(x -> runtimeConfig);
 
-        this.serviceInstanceIdProvider = new ServiceInstanceIdProvider("test-instance", "id");
+        this.uidInstanceIdProvider = new UidInstanceIdProvider("test-instance", "id");
 
-        this.uidOperatorVerticle = new ExtendedUIDOperatorVerticle(configStore, config, config.getBoolean("client_side_token_generate"), siteProvider, clientKeyProvider, clientSideKeypairProvider, new KeyManager(keysetKeyStore, keysetProvider), saltProvider,  optOutStore, clock, statsCollectorQueue, secureLinkValidatorService, shutdownHandler::handleSaltRetrievalResponse, serviceInstanceIdProvider);
+        this.uidOperatorVerticle = new ExtendedUIDOperatorVerticle(configStore, config, config.getBoolean("client_side_token_generate"), siteProvider, clientKeyProvider, clientSideKeypairProvider, new KeyManager(keysetKeyStore, keysetProvider), saltProvider,  optOutStore, clock, statsCollectorQueue, secureLinkValidatorService, shutdownHandler::handleSaltRetrievalResponse, uidInstanceIdProvider);
 
         vertx.deployVerticle(uidOperatorVerticle, testContext.succeeding(id -> testContext.completeNow()));
 

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -2673,7 +2673,7 @@ public class UIDOperatorVerticleTest {
             Handler<AsyncResult<Instant>> handler = invocation.getArgument(2);
             handler.handle(Future.succeededFuture(Instant.now()));
             return null;
-        }).when(this.optOutStore).addEntry(any(), any(), any());
+        }).when(this.optOutStore).addEntry(any(), any(), any(), any(), any());
 
         send("v2", vertx, "v2/token/logout", false, null, req, 200, respJson -> {
             assertEquals("success", respJson.getString("status"));
@@ -2697,7 +2697,7 @@ public class UIDOperatorVerticleTest {
             Handler<AsyncResult<Instant>> handler = invocation.getArgument(2);
             handler.handle(Future.succeededFuture(Instant.now()));
             return null;
-        }).when(this.optOutStore).addEntry(any(), any(), any());
+        }).when(this.optOutStore).addEntry(any(), any(), any(), any(), any());
 
         send("v2", vertx, "v2/token/logout", false, null, req, 200, respJson -> {
             assertEquals("success", respJson.getString("status"));

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -16,6 +16,7 @@ import com.uid2.operator.util.Tuple;
 import com.uid2.operator.vertx.OperatorShutdownHandler;
 import com.uid2.operator.vertx.UIDOperatorVerticle;
 import com.uid2.shared.Utils;
+import com.uid2.shared.audit.Audit;
 import com.uid2.shared.audit.UidInstanceIdProvider;
 import com.uid2.shared.auth.ClientKey;
 import com.uid2.shared.auth.Keyset;
@@ -45,6 +46,7 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.checkerframework.checker.units.qual.C;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -243,6 +245,10 @@ public class UIDOperatorVerticleTest {
     }
 
     private void send(String apiVersion, Vertx vertx, String endpoint, boolean isV1Get, String v1GetParam, JsonObject postPayload, int expectedHttpCode, Handler<JsonObject> handler) {
+        send(apiVersion, vertx, endpoint, isV1Get, v1GetParam, postPayload, expectedHttpCode, handler, Collections.emptyMap());
+    }
+
+    private void send(String apiVersion, Vertx vertx, String endpoint, boolean isV1Get, String v1GetParam, JsonObject postPayload, int expectedHttpCode, Handler<JsonObject> handler, Map<String, String> additionalHeaders) {
         if (apiVersion.equals("v2")) {
             ClientKey ck = (ClientKey) clientKeyProvider.get("");
 
@@ -262,19 +268,19 @@ public class UIDOperatorVerticleTest {
                 } else {
                     handler.handle(tryParseResponse(ar.result()));
                 }
-            });
+            }, additionalHeaders);
         } else if (isV1Get) {
             get(vertx, endpoint + (v1GetParam != null ? "?" + v1GetParam : ""), ar -> {
                 assertTrue(ar.succeeded());
                 assertEquals(expectedHttpCode, ar.result().statusCode());
                 handler.handle(tryParseResponse(ar.result()));
-            });
+            }, additionalHeaders);
         } else {
             post(vertx, endpoint, postPayload, ar -> {
                 assertTrue(ar.succeeded());
                 assertEquals(expectedHttpCode, ar.result().statusCode());
                 handler.handle(tryParseResponse(ar.result()));
-            });
+            }, additionalHeaders);
         }
     }
 
@@ -289,10 +295,10 @@ public class UIDOperatorVerticleTest {
     }
 
     private void sendTokenGenerate(String apiVersion, Vertx vertx, String v1GetParam, JsonObject v2PostPayload, int expectedHttpCode, String referer, Handler<JsonObject> handler, boolean additionalParams) {
-        sendTokenGenerate(apiVersion, vertx, v1GetParam, v2PostPayload, expectedHttpCode, referer, handler, additionalParams, null, null);
+        sendTokenGenerate(apiVersion, vertx, v1GetParam, v2PostPayload, expectedHttpCode, referer, handler, additionalParams, Collections.emptyMap());
     }
 
-    private void sendTokenGenerate(String apiVersion, Vertx vertx, String v1GetParam, JsonObject v2PostPayload, int expectedHttpCode, String referer, Handler<JsonObject> handler, boolean additionalParams, String headerName, String headerValue) {
+    private void sendTokenGenerate(String apiVersion, Vertx vertx, String v1GetParam, JsonObject v2PostPayload, int expectedHttpCode, String referer, Handler<JsonObject> handler, boolean additionalParams, Map<String, String> additionalHeaders) {
         if (apiVersion.equals("v2")) {
             ClientKey ck = (ClientKey) clientKeyProvider.get("");
 
@@ -319,29 +325,31 @@ public class UIDOperatorVerticleTest {
                 } else {
                     handler.handle(tryParseResponse(ar.result()));
                 }
-            }, headerName, headerValue);
+            }, additionalHeaders);
         } else {
             get(vertx, apiVersion + "/token/generate" + (v1GetParam != null ? "?" + v1GetParam : ""), ar -> {
                 assertTrue(ar.succeeded());
                 assertEquals(expectedHttpCode, ar.result().statusCode());
                 handler.handle(tryParseResponse(ar.result()));
-            }, headerName, headerValue);
+            }, additionalHeaders);
         }
     }
 
     private void sendTokenRefresh(String apiVersion, Vertx vertx, VertxTestContext testContext, String refreshToken, String v2RefreshDecryptSecret, int expectedHttpCode,
                                   Handler<JsonObject> handler) {
-        sendTokenRefresh(apiVersion, vertx, null, null, testContext, refreshToken, v2RefreshDecryptSecret, expectedHttpCode, handler);
+        sendTokenRefresh(apiVersion, vertx, testContext, refreshToken, v2RefreshDecryptSecret, expectedHttpCode, handler, Collections.emptyMap());
     }
 
-    private void sendTokenRefresh(String apiVersion, Vertx vertx, String headerName, String headerValue, VertxTestContext testContext, String refreshToken, String v2RefreshDecryptSecret, int expectedHttpCode,
-                                  Handler<JsonObject> handler) {
+    private void sendTokenRefresh(String apiVersion, Vertx vertx, VertxTestContext testContext, String refreshToken, String v2RefreshDecryptSecret, int expectedHttpCode,
+                                  Handler<JsonObject> handler, Map<String, String> additionalHeaders) {
         if (apiVersion.equals("v2")) {
             WebClient client = WebClient.create(vertx);
             HttpRequest<Buffer> refreshHttpRequest = client.postAbs(getUrlForEndpoint("v2/token/refresh"));
-            if (headerName != null) {
-                refreshHttpRequest.putHeader(headerName, headerValue);
+
+            for (Map.Entry<String, String> entry : additionalHeaders.entrySet()) {
+                refreshHttpRequest.putHeader(entry.getKey(), entry.getValue());
             }
+
             refreshHttpRequest
                     .putHeader("content-type", "text/plain")
                     .sendBuffer(Buffer.buffer(refreshToken.getBytes(StandardCharsets.UTF_8)), testContext.succeeding(response -> testContext.verify(() -> {
@@ -364,7 +372,7 @@ public class UIDOperatorVerticleTest {
                 assertEquals(expectedHttpCode, response.statusCode());
                 JsonObject json = response.bodyAsJsonObject();
                 handler.handle(json);
-            })), headerName, headerValue);
+            })), additionalHeaders);
         }
     }
 
@@ -396,40 +404,42 @@ public class UIDOperatorVerticleTest {
     }
 
     private void get(Vertx vertx, String endpoint, Handler<AsyncResult<HttpResponse<Buffer>>> handler) {
-        WebClient client = WebClient.create(vertx);
-        ClientKey ck = clientKeyProvider.getClientKey("");
-        HttpRequest<Buffer> req = client.getAbs(getUrlForEndpoint(endpoint));
-        if (ck != null)
-            req.putHeader("Authorization", "Bearer " + clientKey);
-        req.send(handler);
+        get(vertx, endpoint, handler, Collections.emptyMap());
     }
 
-    private void get(Vertx vertx, String endpoint, Handler<AsyncResult<HttpResponse<Buffer>>> handler, String headerName, String headerValue) {
+    private void get(Vertx vertx, String endpoint, Handler<AsyncResult<HttpResponse<Buffer>>> handler, Map<String, String> additionalHeaders) {
         WebClient client = WebClient.create(vertx);
         ClientKey ck = clientKeyProvider.getClientKey("");
         HttpRequest<Buffer> req = client.getAbs(getUrlForEndpoint(endpoint));
         if (ck != null) {
             req.putHeader("Authorization", "Bearer " + clientKey);
         }
-        if (headerName != null) {
-            req.putHeader(headerName, headerValue);
+
+        for (Map.Entry<String, String> entry : additionalHeaders.entrySet()) {
+            req.putHeader(entry.getKey(), entry.getValue());
         }
+
         req.send(handler);
     }
 
-    private void post(Vertx vertx, String endpoint, JsonObject body, Handler<AsyncResult<HttpResponse<Buffer>>> handler) {
+    private void post(Vertx vertx, String endpoint, JsonObject body, Handler<AsyncResult<HttpResponse<Buffer>>> handler, Map<String, String> additionalHeaders) {
         WebClient client = WebClient.create(vertx);
         ClientKey ck = clientKeyProvider.getClientKey("");
         HttpRequest<Buffer> req = client.postAbs(getUrlForEndpoint(endpoint));
         if (ck != null)
             req.putHeader("Authorization", "Bearer " + clientKey);
+
+        for (Map.Entry<String, String> entry : additionalHeaders.entrySet()) {
+            req.putHeader(entry.getKey(), entry.getValue());
+        }
+
         req.sendJsonObject(body, handler);
     }
 
     private void postV2(ClientKey ck, Vertx vertx, String endpoint, JsonObject body, long nonce, String referer, Handler<AsyncResult<HttpResponse<Buffer>>> handler) {
-        postV2(ck, vertx, endpoint, body, nonce, referer, handler, null, null);
+        postV2(ck, vertx, endpoint, body, nonce, referer, handler, Collections.emptyMap());
     }
-    private void postV2(ClientKey ck, Vertx vertx, String endpoint, JsonObject body, long nonce, String referer, Handler<AsyncResult<HttpResponse<Buffer>>> handler, String headerName, String headerValue) {
+    private void postV2(ClientKey ck, Vertx vertx, String endpoint, JsonObject body, long nonce, String referer, Handler<AsyncResult<HttpResponse<Buffer>>> handler, Map<String, String> additionalHeaders) {
         WebClient client = WebClient.create(vertx);
 
         Buffer b = Buffer.buffer();
@@ -449,8 +459,9 @@ public class UIDOperatorVerticleTest {
         HttpRequest<Buffer> request = client.postAbs(getUrlForEndpoint(endpoint))
                 .putHeader("Authorization", "Bearer " + apiKey)
                 .putHeader("content-type", "text/plain");
-        if (headerName != null) {
-            request.putHeader(headerName, headerValue);
+
+        for (Map.Entry<String, String> entry : additionalHeaders.entrySet()) {
+            request.putHeader(entry.getKey(), entry.getValue());
         }
 
         if (referer != null) {
@@ -626,14 +637,14 @@ public class UIDOperatorVerticleTest {
     }
 
     private void generateTokens(String apiVersion, Vertx vertx, String inputType, String input, Handler<JsonObject> handler) {
-        generateTokens(apiVersion, vertx, inputType, input,  handler, null, null);
+        generateTokens(apiVersion, vertx, inputType, input,  handler, Collections.emptyMap());
     }
 
-    private void generateTokens(String apiVersion, Vertx vertx, String inputType, String input, Handler<JsonObject> handler, String headerName, String headerValue) {
+    private void generateTokens(String apiVersion, Vertx vertx, String inputType, String input, Handler<JsonObject> handler, Map<String, String> additionalHeaders) {
         String v1Param = inputType + "=" + urlEncode(input);
         JsonObject v2Payload = new JsonObject();
         v2Payload.put(inputType, input);
-        sendTokenGenerate(apiVersion, vertx, v1Param, v2Payload, 200, null, handler, true, headerName, headerValue);
+        sendTokenGenerate(apiVersion, vertx, v1Param, v2Payload, 200, null, handler, true, additionalHeaders);
     }
 
     private static void assertEqualsClose(Instant expected, Instant actual, int withinSeconds) {
@@ -1453,7 +1464,7 @@ public class UIDOperatorVerticleTest {
                             TokenResponseStatsCollector.ResponseStatus.Success,
                             TokenResponseStatsCollector.PlatformType.Other);
 
-                    sendTokenRefresh("v2", vertx, ClientVersionHeader, tvosClientVersionHeaderValue, testContext, body.getString("refresh_token"), body.getString("refresh_response_key"), 200, refreshRespJson ->
+                    sendTokenRefresh("v2", vertx, testContext, body.getString("refresh_token"), body.getString("refresh_response_key"), 200, refreshRespJson ->
                     {
                         assertEquals("optout", refreshRespJson.getString("status"));
                         JsonObject refreshBody = refreshRespJson.getJsonObject("body");
@@ -1464,7 +1475,7 @@ public class UIDOperatorVerticleTest {
                                 TokenResponseStatsCollector.ResponseStatus.OptOut,
                                 TokenResponseStatsCollector.PlatformType.InApp);
                         testContext.completeNow();
-                    });
+                    }, Map.of(ClientVersionHeader, tvosClientVersionHeaderValue));
                 });
     }
 
@@ -1604,6 +1615,8 @@ public class UIDOperatorVerticleTest {
         setupSalts();
         setupKeys();
 
+        Map<String, String> additionalHeaders = Map.of(ClientVersionHeader, iosClientVersionHeaderValue);
+
         generateTokens(apiVersion, vertx, "email", emailAddress, genRespJson -> {
             assertEquals("success", genRespJson.getString("status"));
             JsonObject bodyJson = genRespJson.getJsonObject("body");
@@ -1613,7 +1626,7 @@ public class UIDOperatorVerticleTest {
 
             when(this.optOutStore.getLatestEntry(any())).thenReturn(null);
 
-            sendTokenRefresh(apiVersion,  vertx, ClientVersionHeader, iosClientVersionHeaderValue, testContext, genRefreshToken, bodyJson.getString("refresh_response_key"), 200, refreshRespJson ->
+            sendTokenRefresh(apiVersion,  vertx, testContext, genRefreshToken, bodyJson.getString("refresh_response_key"), 200, refreshRespJson ->
             {
                 assertEquals("success", refreshRespJson.getString("status"));
                 JsonObject refreshBody = refreshRespJson.getJsonObject("body");
@@ -1649,8 +1662,8 @@ public class UIDOperatorVerticleTest {
                         TokenResponseStatsCollector.PlatformType.InApp);
 
                 testContext.completeNow();
-            });
-        }, ClientVersionHeader, iosClientVersionHeaderValue);
+            }, additionalHeaders);
+        }, additionalHeaders);
     }
 
     @ParameterizedTest
@@ -1663,6 +1676,8 @@ public class UIDOperatorVerticleTest {
         setupSalts();
         setupKeys();
 
+        Map<String, String> additionalHeaders = Map.of(ClientVersionHeader, androidClientVersionHeaderValue);
+
         generateTokens(apiVersion, vertx, "email", emailAddress, genRespJson -> {
             assertEquals("success", genRespJson.getString("status"));
             JsonObject bodyJson = genRespJson.getJsonObject("body");
@@ -1672,7 +1687,7 @@ public class UIDOperatorVerticleTest {
 
             when(this.optOutStore.getLatestEntry(any())).thenReturn(null);
 
-            sendTokenRefresh(apiVersion, vertx, ClientVersionHeader, androidClientVersionHeaderValue, testContext, genRefreshToken, bodyJson.getString("refresh_response_key"), 200, refreshRespJson ->
+            sendTokenRefresh(apiVersion, vertx, testContext, genRefreshToken, bodyJson.getString("refresh_response_key"), 200, refreshRespJson ->
             {
                 assertEquals("success", refreshRespJson.getString("status"));
                 JsonObject refreshBody = refreshRespJson.getJsonObject("body");
@@ -1710,8 +1725,8 @@ public class UIDOperatorVerticleTest {
                 verify(shutdownHandler, atLeastOnce()).handleSaltRetrievalResponse(true);
 
                 testContext.completeNow();
-            });
-        }, ClientVersionHeader, androidClientVersionHeaderValue);
+            }, additionalHeaders);
+        }, additionalHeaders);
     }
 
     @Test
@@ -1735,12 +1750,12 @@ public class UIDOperatorVerticleTest {
                     String genRefreshToken = bodyJson.getString("refresh_token");
 
                     setupKeys(true);
-                    sendTokenRefresh("v2", vertx, ClientVersionHeader, androidClientVersionHeaderValue, testContext, genRefreshToken, bodyJson.getString("refresh_response_key"), 500, refreshRespJson ->
+                    sendTokenRefresh("v2", vertx, testContext, genRefreshToken, bodyJson.getString("refresh_response_key"), 500, refreshRespJson ->
                     {
                         assertFalse(refreshRespJson.containsKey("body"));
                         assertEquals("No active encryption key available", refreshRespJson.getString("message"));
                         testContext.completeNow();
-                    });
+                    }, Map.of(ClientVersionHeader, androidClientVersionHeaderValue));
                 });
     }
 
@@ -1939,7 +1954,7 @@ public class UIDOperatorVerticleTest {
     void tokenRefreshNoToken(String apiVersion, Vertx vertx, VertxTestContext testContext) {
         final int clientSiteId = 201;
         fakeAuth(clientSiteId, Role.GENERATOR);
-        sendTokenRefresh(apiVersion, vertx, null, null, testContext, "", "", 400, json -> {
+        sendTokenRefresh(apiVersion, vertx, testContext, "", "", 400, json -> {
             assertEquals("invalid_token", json.getString("status"));
             assertTokenStatusMetrics(
                     clientSiteId,
@@ -1956,7 +1971,7 @@ public class UIDOperatorVerticleTest {
         final int clientSiteId = 201;
         fakeAuth(clientSiteId, Role.GENERATOR);
 
-        sendTokenRefresh(apiVersion, vertx, ORIGIN_HEADER, "example.com", testContext, token, "", 400, json -> {
+        sendTokenRefresh(apiVersion, vertx, testContext, token, "", 400, json -> {
             assertEquals("invalid_token", json.getString("status"));
             assertTokenStatusMetrics(
                     clientSiteId,
@@ -1964,13 +1979,13 @@ public class UIDOperatorVerticleTest {
                     TokenResponseStatsCollector.ResponseStatus.InvalidToken,
                     TokenResponseStatsCollector.PlatformType.HasOriginHeader);
             testContext.completeNow();
-        });
+        }, Map.of(ORIGIN_HEADER, "https://example.com"));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"v1", "v2"})
     void tokenRefreshInvalidTokenUnauthenticated(String apiVersion, Vertx vertx, VertxTestContext testContext) {
-        sendTokenRefresh(apiVersion, vertx, null, null, testContext, "abcd", "", 400, json -> {
+        sendTokenRefresh(apiVersion, vertx, testContext, "abcd", "", 400, json -> {
             assertEquals("error", json.getString("status"));
             testContext.completeNow();
         });
@@ -2677,13 +2692,13 @@ public class UIDOperatorVerticleTest {
             Handler<AsyncResult<Instant>> handler = invocation.getArgument(4);
             handler.handle(Future.succeededFuture(Instant.now()));
             return null;
-        }).when(this.optOutStore).addEntry(any(), any(), any(), any(), any());
+        }).when(this.optOutStore).addEntry(any(), any(), eq("uid-trace-id"), eq("test-instance-id"), any());
 
         send("v2", vertx, "v2/token/logout", false, null, req, 200, respJson -> {
             assertEquals("success", respJson.getString("status"));
             assertEquals("OK", respJson.getJsonObject("body").getString("optout"));
             testContext.completeNow();
-        });
+        }, Map.of(Audit.UID_TRACE_ID_HEADER, "uid-trace-id"));
     }
 
     @Test

--- a/src/test/java/com/uid2/operator/benchmark/BenchmarkCommon.java
+++ b/src/test/java/com/uid2/operator/benchmark/BenchmarkCommon.java
@@ -191,7 +191,7 @@ public class BenchmarkCommon {
         }
 
         @Override
-        public void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, String uidTraceId, String serviceInstanceId, Handler<AsyncResult<Instant>> handler) {
+        public void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, String uidTraceId, String uidInstanceId, Handler<AsyncResult<Instant>> handler) {
             // noop
         }
 

--- a/src/test/java/com/uid2/operator/benchmark/BenchmarkCommon.java
+++ b/src/test/java/com/uid2/operator/benchmark/BenchmarkCommon.java
@@ -9,7 +9,7 @@ import com.uid2.operator.service.UIDOperatorService;
 import com.uid2.operator.store.CloudSyncOptOutStore;
 import com.uid2.operator.store.IOptOutStore;
 import com.uid2.shared.Utils;
-import com.uid2.shared.audit.ServiceInstanceIdProvider;
+import com.uid2.shared.audit.UidInstanceIdProvider;
 import com.uid2.shared.auth.ClientKey;
 import com.uid2.shared.auth.Role;
 import com.uid2.shared.cloud.CloudStorageException;
@@ -79,7 +79,7 @@ public class BenchmarkCommon {
                 IdentityScope.UID2,
                 null,
                 false,
-                new ServiceInstanceIdProvider("test-instance", "id")
+                new UidInstanceIdProvider("test-instance", "id")
         );
     }
 

--- a/src/test/java/com/uid2/operator/benchmark/BenchmarkCommon.java
+++ b/src/test/java/com/uid2/operator/benchmark/BenchmarkCommon.java
@@ -9,6 +9,7 @@ import com.uid2.operator.service.UIDOperatorService;
 import com.uid2.operator.store.CloudSyncOptOutStore;
 import com.uid2.operator.store.IOptOutStore;
 import com.uid2.shared.Utils;
+import com.uid2.shared.audit.ServiceInstanceIdProvider;
 import com.uid2.shared.auth.ClientKey;
 import com.uid2.shared.auth.Role;
 import com.uid2.shared.cloud.CloudStorageException;
@@ -77,7 +78,8 @@ public class BenchmarkCommon {
                 Clock.systemUTC(),
                 IdentityScope.UID2,
                 null,
-                false
+                false,
+                new ServiceInstanceIdProvider("test-instance", "id")
         );
     }
 
@@ -189,7 +191,7 @@ public class BenchmarkCommon {
         }
 
         @Override
-        public void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, Handler<AsyncResult<Instant>> handler) {
+        public void addEntry(UserIdentity firstLevelHashIdentity, byte[] advertisingId, String uidTraceId, String serviceInstanceId, Handler<AsyncResult<Instant>> handler) {
             // noop
         }
 


### PR DESCRIPTION
Changes in this PR and [Shared PR](https://github.com/IABTechLab/uid2-shared/pull/457/files):
- Added instance ID configs for local Operators
- Initialised the UidInstanceIdProvider and passed it to where it's needed
- Attached UID-Instance-Id header to all requests made to Core and Opt Out
- Forwarded UID-Trace-Id header for logout requests

Tested locally in dev workspace:

- UID instance ID is being populated in headers in all requests to Core
- Core is receiving the instance ID and adding it to audit logs

<img width="1438" alt="Screenshot 2025-06-05 at 9 54 17 pm" src="https://github.com/user-attachments/assets/a00a74db-3aed-48bf-9a42-f0274c365aed" />

