### PR TITLE
Always use millisecond precision for ISO8601 timestamps in identity/buckets

### DIFF
--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -86,7 +86,9 @@ public class UIDOperatorVerticle extends AbstractVerticle {
      */
     public static final Duration TOKEN_LIFETIME_TOLERANCE = Duration.ofSeconds(10);
     private static final long SECOND_IN_MILLIS = 1000;
-    private static final DateTimeFormatter API_DATE_TIME_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneOffset.UTC);
+    // Use a formatter that always prints three-digit millisecond precision (e.g. 2024-07-02T14:15:16.000)
+    private static final DateTimeFormatter API_DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
 
     private static final String REQUEST = "request";
     private final HealthComponent healthComponent = HealthManager.instance.registerComponent("http-server");

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -5677,11 +5677,10 @@ public class UIDOperatorVerticleTest {
     }
 
     private void assertLastUpdatedHasMillis(JsonArray buckets) {
-        assertFalse(buckets.isEmpty());
         for (int i = 0; i < buckets.size(); i++) {
             JsonObject bucket = buckets.getJsonObject(i);
             String lastUpdated = bucket.getString("last_updated");
-            // Expect the pattern yyyy-MM-dd'T'HH:mm:ss.SSS with millisecond component always present
+            // Verify pattern yyyy-MM-dd'T'HH:mm:ss.SSS 
             assertTrue(lastUpdated.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}"),
                     "last_updated does not contain millisecond precision: " + lastUpdated);
         }
@@ -5694,12 +5693,12 @@ public class UIDOperatorVerticleTest {
         fakeAuth(clientSiteId, Role.MAPPER);
         setupSalts();
 
-        // Prepare a SaltEntry with a lastUpdated that has 0 milliseconds so we can verify formatter adds .000
+        // SaltEntry with a lastUpdated that has 0 milliseconds
         long lastUpdatedMillis = Instant.parse("2024-01-01T00:00:00Z").toEpochMilli();
         SaltEntry bucketEntry = new SaltEntry(456, "hashed456", lastUpdatedMillis, "salt456", null, null, null, null);
         when(saltProviderSnapshot.getModifiedSince(any())).thenReturn(List.of(bucketEntry));
 
-        String sinceTimestamp = "2023-12-31T00:00:00"; // earlier than bucketEntry.lastUpdated
+        String sinceTimestamp = "2023-12-31T00:00:00"; // earlier timestamp
 
         boolean isV1 = apiVersion.equals("v1");
         String v1Param = isV1 ? "since_timestamp=" + sinceTimestamp : null;
@@ -5707,6 +5706,7 @@ public class UIDOperatorVerticleTest {
 
         send(apiVersion, vertx, apiVersion + "/identity/buckets", isV1, v1Param, req, 200, respJson -> {
             JsonArray buckets = respJson.getJsonArray("body");
+            assertFalse(buckets.isEmpty());
             assertLastUpdatedHasMillis(buckets);
             testContext.completeNow();
         });

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -5675,4 +5675,40 @@ public class UIDOperatorVerticleTest {
             testContext.completeNow();
         });
     }
+
+    private void assertLastUpdatedHasMillis(JsonArray buckets) {
+        assertFalse(buckets.isEmpty());
+        for (int i = 0; i < buckets.size(); i++) {
+            JsonObject bucket = buckets.getJsonObject(i);
+            String lastUpdated = bucket.getString("last_updated");
+            // Expect the pattern yyyy-MM-dd'T'HH:mm:ss.SSS with millisecond component always present
+            assertTrue(lastUpdated.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}"),
+                    "last_updated does not contain millisecond precision: " + lastUpdated);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"v1", "v2"})
+    void identityBucketsAlwaysReturnMilliseconds(String apiVersion, Vertx vertx, VertxTestContext testContext) {
+        final int clientSiteId = 201;
+        fakeAuth(clientSiteId, Role.MAPPER);
+        setupSalts();
+
+        // Prepare a SaltEntry with a lastUpdated that has 0 milliseconds so we can verify formatter adds .000
+        long lastUpdatedMillis = Instant.parse("2024-01-01T00:00:00Z").toEpochMilli();
+        SaltEntry bucketEntry = new SaltEntry(456, "hashed456", lastUpdatedMillis, "salt456", null, null, null, null);
+        when(saltProviderSnapshot.getModifiedSince(any())).thenReturn(List.of(bucketEntry));
+
+        String sinceTimestamp = "2023-12-31T00:00:00"; // earlier than bucketEntry.lastUpdated
+
+        boolean isV1 = apiVersion.equals("v1");
+        String v1Param = isV1 ? "since_timestamp=" + sinceTimestamp : null;
+        JsonObject req = isV1 ? null : new JsonObject().put("since_timestamp", sinceTimestamp);
+
+        send(apiVersion, vertx, apiVersion + "/identity/buckets", isV1, v1Param, req, 200, respJson -> {
+            JsonArray buckets = respJson.getJsonArray("body");
+            assertLastUpdatedHasMillis(buckets);
+            testContext.completeNow();
+        });
+    }
 }


### PR DESCRIPTION
Always use millisecond precision for ISO8601 timestamps in identity/buckets