### PR TITLE
upgrade vertx from 4.5.13 to 4.5.18 due to CVE-2025-55163

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <enclave-aws.version>2.1.0</enclave-aws.version>
         <enclave-azure.version>2.1.13</enclave-azure.version>
         <enclave-gcp.version>2.1.0</enclave-gcp.version>
-        <uid2-shared.version>10.8.0</uid2-shared.version>
+        <uid2-shared.version>10.9.0</uid2-shared.version>
         <image.version>${project.version}</image.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.5.13</vertx.version>
+        <vertx.version>4.5.18</vertx.version>
         <vertx-maven-plugin.version>1.0.22</vertx-maven-plugin.version>
         <junit-jupiter.version>5.11.2</junit-jupiter.version>
         <junit-vintage.version>5.11.2</junit-vintage.version>


### PR DESCRIPTION
also upgrade uid2-shared to 10.9.0 which has same vertx upgrade.

https://www.suse.com/security/cve/CVE-2025-55163.html
https://nvd.nist.gov/vuln/detail/CVE-2025-55163


https://github.com/eclipse-vertx/vert.x/compare/4.5.13...4.5.18