### PR TITLE
TEST: Reproduce NoActiveKeyException issue - force refresh key to be …

### DIFF
--- a/src/main/java/com/uid2/operator/model/KeyManager.java
+++ b/src/main/java/com/uid2/operator/model/KeyManager.java
@@ -117,7 +117,11 @@ public class KeyManager {
     }
 
     public KeysetKey getRefreshKey(Instant asOf) {
-        KeysetKey key = this.keysetKeyStore.getSnapshot().getActiveKey(Const.Data.RefreshKeysetId, asOf);
+        // TEMPORARY: Simulate keyset key unavailability to reproduce Univision issue
+        KeysetKey key = null; // Force key to be null to trigger NoActiveKeyException
+        
+        // Original line commented out:
+        // KeysetKey key = this.keysetKeyStore.getSnapshot().getActiveKey(Const.Data.RefreshKeysetId, asOf);
         if (key == null) {
             throw new NoActiveKeyException(String.format("Cannot get a refresh key with keyset ID %d.", Const.Data.RefreshKeysetId));
         }


### PR DESCRIPTION
…null

This simulates the exact Univision issue where keyset keys are unavailable. Expected behavior WITHOUT the fix:
- Operator throws NoActiveKeyException continuously
- APIs return 500 errors
- Operator NEVER shuts down (stays in broken state forever)

This branch is for demonstrating the problem before applying the shutdown handler fix.