### PR TITLE
UID2-6620: Upgrade aquasecurity/trivy-action from 0.14.0 to 0.34.0

### DIFF
--- a/.github/workflows/publish-azure-cc-enclave-docker.yaml
+++ b/.github/workflows/publish-azure-cc-enclave-docker.yaml
@@ -128,7 +128,7 @@ jobs:
             BUILD_TARGET=${{ env.ENCLAVE_PROTOCOL }}
 
       - name: Generate Trivy vulnerability scan report
-        uses: aquasecurity/trivy-action@0.14.0
+        uses: aquasecurity/trivy-action@0.34.0
         with:
           image-ref: ${{ steps.meta.outputs.tags }}
           format: 'sarif'
@@ -144,7 +144,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Test with Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.14.0
+        uses: aquasecurity/trivy-action@0.34.0
         with:
           image-ref: ${{ steps.meta.outputs.tags }}
           format: 'table'

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.66.5</version>
+    <version>5.66.6-alpha-665-SNAPSHOT</version>
   
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Summary

- The Azure Private Operator Build Image job was failing because `aquasecurity/trivy-action@0.14.0` contains a Docker client using API version 1.43
- The GitHub Actions runner's Docker daemon now requires a minimum API version of 1.44, causing the Trivy scan step to fail with: `client version 1.43 is too old. Minimum supported API version is 1.44`
- Upgraded both trivy-action usages (SARIF report generation and vulnerability test) from `0.14.0` to `0.34.0`

## Test plan

- [ ] Verify the Azure Private Operator / Build Image job passes the "Generate Trivy vulnerability scan report" step
- [ ] Verify the "Test with Trivy vulnerability scanner" step also passes
- [ ] Confirm the Docker image is successfully pushed after the scan

Fixes: https://github.com/IABTechLab/uid2-operator/actions/runs/22162906844/job/64083854196
Jira: https://thetradedesk.atlassian.net/browse/UID2-6620

🤖 Generated with [Claude Code](https://claude.com/claude-code)