### PR TITLE
UID2-6905: upgrade libcrypto3/libssl3 to fix CVE-2026-28390 (HIGH)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 FROM eclipse-temurin@sha256:693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
 
 # For Amazon Corretto Crypto Provider
-RUN apk add --no-cache gcompat
+# CVE-2026-28390: upgrade libcrypto3/libssl3 to 3.5.6-r0+ (UID2-6905)
+RUN apk add --no-cache gcompat && apk upgrade --no-cache libcrypto3 libssl3
 
 WORKDIR /app
 EXPOSE 8080


### PR DESCRIPTION
## Summary

Fixes CVE-2026-28390 (HIGH severity) — OpenSSL Denial of Service via NULL pointer dereference in `libcrypto3`.

- **Vulnerable package:** `libcrypto3` / `libssl3` (Alpine)
- **Vulnerable version:** `3.5.5-r0`
- **Fixed version:** `3.5.6-r0`
- **Jira:** https://thetradedesk.atlassian.net/browse/UID2-6905

## Change

Added `libcrypto3 libssl3` to the `apk upgrade` call in `Dockerfile` so the patched Alpine packages are installed at image build time.

## Test plan

- [ ] CI vulnerability scan passes (Trivy no longer reports CVE-2026-28390)
- [ ] Build and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)