### PR TITLE
UID2-6913: Pin third-party GitHub Action refs to commit SHAs

### DIFF
--- a/.github/actions/build_ami/action.yaml
+++ b/.github/actions/build_ami/action.yaml
@@ -71,7 +71,7 @@ runs:
 
     - name: Get EIF for Run ${{ inputs.operator_run_number }}
       id: get_eif_for_run
-      uses: dawidd6/action-download-artifact@v6
+      uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
       if: ${{ inputs.operator_release == '' }}
       with:
         name: 'aws-${{ inputs.identity_scope }}-deployment-files-.*'
@@ -94,14 +94,14 @@ runs:
         ls ./scripts/aws/uid2-operator-ami/artifacts/ -al
 
     - name: Configure UID2 AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       if: ${{ inputs.identity_scope == 'uid2' }}
       with:
         aws-region: ${{ inputs.uid2_aws_region }}
         role-to-assume: ${{ inputs.uid2_aws_role }}
 
     - name: Configure EUID AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       if: ${{ inputs.identity_scope == 'euid' }}
       with:
         aws-region: ${{ inputs.euid_aws_region }}
@@ -124,7 +124,7 @@ runs:
 
     - name: Setup Packer
       id: setup-packer
-      uses: hashicorp/setup-packer@main
+      uses: hashicorp/setup-packer@c3d53c525d422944e50ee27b840746d6522b08de # main
 
     - name: Create AMI
       shell: bash

--- a/.github/actions/build_aws_eif/action.yaml
+++ b/.github/actions/build_aws_eif/action.yaml
@@ -38,7 +38,7 @@ runs:
         fetch-depth: 0
 
     - name: Restore timestamps
-      uses: thetradedesk/git-restore-mtime-action@v1.3
+      uses: thetradedesk/git-restore-mtime-action@a6059d100648f8027eb1af5e6e6fd6e1328083af # v1.3
 
     - name: Free up space - delete preinstalled tools
       shell: bash

--- a/.github/actions/build_eks_docker_image/action.yaml
+++ b/.github/actions/build_eks_docker_image/action.yaml
@@ -59,7 +59,7 @@ runs:
 
     - name: Get EIF for Run ${{ inputs.operator_run_number }}
       id: get_eif_for_run
-      uses: dawidd6/action-download-artifact@v6
+      uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
       if: ${{ inputs.operator_release == '' }}
       with:
         name: 'aws-${{ inputs.identity_scope }}-deployment-files-.*'
@@ -112,7 +112,7 @@ runs:
         df -h
 
     - name: Log in to the Docker container registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -120,14 +120,14 @@ runs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-eks-${{ inputs.identity_scope }}
         tags: |
           type=raw,value=${{ steps.versionNumber.outputs.VERSION_NUMBER }}.${{ github.run_number }}
 
     - name: Build and export to Docker
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: ${{ inputs.artifacts_output_dir }}
         load: true
@@ -140,7 +140,7 @@ runs:
 
     - name: Push to Docker
       id: push-to-docker
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
       with:
         context: ${{ inputs.artifacts_output_dir }}
         push: true

--- a/.github/actions/update_operator_version/action.yaml
+++ b/.github/actions/update_operator_version/action.yaml
@@ -40,7 +40,7 @@ runs:
 
     - name: Approve Major release
       if: inputs.release_type == 'Major'
-      uses: trstringer/manual-approval@v1
+      uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1
       with:
         secret: ${{ github.token }}
         approvers: atarassov-ttd,vishalegbert-ttd,sunnywu,clarkxuyang
@@ -77,7 +77,7 @@ runs:
         fetch-depth: 0
 
     - name: Restore timestamps
-      uses: thetradedesk/git-restore-mtime-action@v1.3
+      uses: thetradedesk/git-restore-mtime-action@a6059d100648f8027eb1af5e6e6fd6e1328083af # v1.3
 
     - name: Set version number
       id: version

--- a/.github/workflows/build-uid2-ami.yaml
+++ b/.github/workflows/build-uid2-ami.yaml
@@ -135,7 +135,7 @@ jobs:
           path: ./artifacts
 
       - name: Delete staging artifacts
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@b54d29a59e55046d1f7fc8226cdda507e6b9cf62 # v5
         with: 
           name: |
             uid2_AMI_measurement

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -43,7 +43,7 @@ jobs:
           echo "vulnerability_severity=${VULNERABILITY_SEVERITY}" >> $GITHUB_OUTPUT
       - name: Approve Major release
         if: env.RELEASE_TYPE == 'Major'
-        uses: trstringer/manual-approval@v1
+        uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1
         with:
           secret: ${{ github.token }}
           approvers: atarassov-ttd,vishalegbert-ttd,sunnywu,clarkxuyang
@@ -208,7 +208,7 @@ jobs:
 
       - name: Build changelog
         id: changelog
-        uses: mikepenz/release-changelog-builder-action@v4
+        uses: mikepenz/release-changelog-builder-action@32e3c96f29a6532607f638797455e9e98cfc703d # v4
         with:
           toTag: v${{ needs.start.outputs.new_version }}
           configurationJson: |
@@ -229,7 +229,7 @@ jobs:
           (cd manifests && zip -r ../uid2-operator-release-manifests-${{ needs.start.outputs.new_version }}.zip .)
 
       - name: Create draft release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           name: v${{ needs.start.outputs.new_version }}
           body: ${{ steps.changelog.outputs.changelog }}
@@ -253,4 +253,4 @@ jobs:
             SLACK_MESSAGE: ':x: Operator Pipeline failed'
             SLACK_TITLE: Pipeline Failed in ${{ github.workflow }}
             SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          uses: rtCamp/action-slack-notify@v2
+          uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2

--- a/.github/workflows/publish-aws-nitro-eif.yaml
+++ b/.github/workflows/publish-aws-nitro-eif.yaml
@@ -180,7 +180,7 @@ jobs:
       - name: Build changelog
         id: github_release
         if: ${{ inputs.version_number_input == '' && needs.start.outputs.is_release == 'true' }}
-        uses: mikepenz/release-changelog-builder-action@v4
+        uses: mikepenz/release-changelog-builder-action@32e3c96f29a6532607f638797455e9e98cfc703d # v4
         with:
           configurationJson: |
             {
@@ -192,7 +192,7 @@ jobs:
 
       - name: Create release
         if: ${{ inputs.version_number_input == '' && needs.start.outputs.is_release == 'true' }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           name: ${{ needs.start.outputs.new_version }}
           body: ${{ steps.github_release.outputs.changelog }}

--- a/.github/workflows/publish-azure-cc-enclave-docker.yaml
+++ b/.github/workflows/publish-azure-cc-enclave-docker.yaml
@@ -101,7 +101,7 @@ jobs:
           cp scripts/confidential_compute.py ${{ env.DOCKER_CONTEXT_PATH }}/
 
       - name: Log in to the Docker container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -109,14 +109,14 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ steps.update_version.outputs.image_tag }}
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ${{ env.DOCKER_CONTEXT_PATH }}
           load: true
@@ -155,7 +155,7 @@ jobs:
 
       - name: Push to Docker
         id: push-to-docker
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ${{ env.DOCKER_CONTEXT_PATH }}
           push: true

--- a/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
+++ b/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
@@ -99,7 +99,7 @@ jobs:
           cp scripts/confidential_compute.py ${{ env.DOCKER_CONTEXT_PATH }}/
 
       - name: Log in to the Docker container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Authenticate with Google Cloud
         id: gcp_auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           token_format: access_token
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER_ID }}
@@ -115,7 +115,7 @@ jobs:
           access_token_lifetime: 300s
 
       - name: Log in to the GCP Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.GCP_REGISTRY }}
           username: oauth2accesstoken
@@ -123,7 +123,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -131,7 +131,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for GCP image
         id: meta-gcp
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.GCP_REGISTRY }}/${{ env.GCP_GAR_PROJECT }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -139,7 +139,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for all Docker images
         id: meta-all
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -148,7 +148,7 @@ jobs:
             type=raw,value=${{ steps.update_version.outputs.new_version }}-${{ env.ENCLAVE_PROTOCOL }}
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ${{ env.DOCKER_CONTEXT_PATH }}
           load: true
@@ -169,7 +169,7 @@ jobs:
 
       - name: Push to Docker
         id: push-to-docker
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ${{ env.DOCKER_CONTEXT_PATH }}
           push: true
@@ -211,7 +211,7 @@ jobs:
       - name: Build changelog
         id: github_release
         if: ${{ inputs.version_number_input == '' && steps.update_version.outputs.is_release == 'true' }}
-        uses: mikepenz/release-changelog-builder-action@v4
+        uses: mikepenz/release-changelog-builder-action@32e3c96f29a6532607f638797455e9e98cfc703d # v4
         with:
           configurationJson: |
             {
@@ -223,7 +223,7 @@ jobs:
 
       - name: Create release
         if: ${{ inputs.version_number_input == '' && steps.update_version.outputs.is_release == 'true' }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           name: ${{ steps.update_version.outputs.new_version }}
           body: ${{ steps.github_release.outputs.changelog }}

--- a/.github/workflows/publish-public-operator-docker-image.yaml
+++ b/.github/workflows/publish-public-operator-docker-image.yaml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: Approve Major release
         if: inputs.release_type == 'Major'
-        uses: trstringer/manual-approval@v1
+        uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1
         with:
           secret: ${{ github.token }}
           approvers: atarassov-ttd,vishalegbert-ttd,sunnywu,clarkxuyang

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "IABTechLab/*": ref-pin  # internal org, tag pinning is acceptable
+        "*": hash-pin            # all external actions must be SHA-pinned

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        "IABTechLab/*": ref-pin  # internal org, tag pinning is acceptable
-        "*": hash-pin            # all external actions must be SHA-pinned


### PR DESCRIPTION
## Summary
Pin third-party (non-GitHub-owned) action references to full-length commit SHAs to mitigate supply-chain attacks from mutable tags.

Only external actions are pinned in this PR (e.g. `docker/*`, `aws-actions/*`, `softprops/*`, etc.). GitHub-owned actions (`actions/*`) are not included in this change.

## Verification
Each SHA can be verified with:
```
git ls-remote https://github.com/<owner>/<repo> <tag>
```

## Test plan
- [ ] Verify CI passes with pinned refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)