### PR TITLE
UID2-6929: CVE-2026-40200 upgrade musl/musl-utils to 1.2.5-r23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM eclipse-temurin@sha256:693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846
 
 # For Amazon Corretto Crypto Provider
 # CVE-2026-28390: upgrade libcrypto3/libssl3 to 3.5.6-r0+ (UID2-6905)
-RUN apk add --no-cache gcompat && apk upgrade --no-cache libcrypto3 libssl3
+RUN apk add --no-cache gcompat && apk upgrade --no-cache libcrypto3 libssl3 musl musl-utils
 
 WORKDIR /app
 EXPOSE 8080


### PR DESCRIPTION
## Summary

CVE-2026-40200 (HIGH): musl libc arbitrary code execution and denial of service vulnerability in `musl`/`musl-utils` 1.2.5-r21. Fixed in 1.2.5-r23.

Adds `musl musl-utils` to the existing `apk upgrade` in the Dockerfile so the patched packages are installed at image build time.