### PR TITLE
UID2-6950: Fix CVE-2026-40200 + CVE-2026-28390 in Azure/GCP operator Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
-FROM eclipse-temurin@sha256:693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
+# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
+FROM eclipse-temurin@sha256:ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
 
 # For Amazon Corretto Crypto Provider
-# CVE-2026-28390: upgrade libcrypto3/libssl3 to 3.5.6-r0+ (UID2-6905)
-RUN apk add --no-cache gcompat && apk upgrade --no-cache libcrypto3 libssl3 musl musl-utils
+RUN apk add --no-cache gcompat
 
 WORKDIR /app
 EXPOSE 8080

--- a/scripts/azure-cc/Dockerfile
+++ b/scripts/azure-cc/Dockerfile
@@ -1,6 +1,9 @@
 # sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
 FROM eclipse-temurin@sha256:693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
 
+# CVE-2026-40200: upgrade musl/musl-utils to 1.2.5-r23+; CVE-2026-28390: upgrade libcrypto3/libssl3 to 3.5.6-r0+
+RUN apk upgrade --no-cache libcrypto3 libssl3 musl musl-utils
+
 # Install necessary packages and set up virtual environment
 RUN apk update && apk add --no-cache jq python3 py3-pip && \
     python3 -m venv /venv && \

--- a/scripts/azure-cc/Dockerfile
+++ b/scripts/azure-cc/Dockerfile
@@ -1,8 +1,5 @@
-# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
-FROM eclipse-temurin@sha256:693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
-
-# CVE-2026-40200: upgrade musl/musl-utils to 1.2.5-r23+; CVE-2026-28390: upgrade libcrypto3/libssl3 to 3.5.6-r0+
-RUN apk upgrade --no-cache libcrypto3 libssl3 musl musl-utils
+# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
+FROM eclipse-temurin@sha256:ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
 
 # Install necessary packages and set up virtual environment
 RUN apk update && apk add --no-cache jq python3 py3-pip && \

--- a/scripts/gcp-oidc/Dockerfile
+++ b/scripts/gcp-oidc/Dockerfile
@@ -4,8 +4,9 @@ FROM eclipse-temurin@sha256:693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846
 LABEL "tee.launch_policy.allow_env_override"="API_TOKEN_SECRET_NAME,DEPLOYMENT_ENVIRONMENT,CORE_BASE_URL,OPTOUT_BASE_URL,DEBUG_MODE,SKIP_VALIDATIONS"
 LABEL "tee.launch_policy.log_redirect"="always"
 
+# CVE-2026-40200: upgrade musl/musl-utils to 1.2.5-r23+; CVE-2026-28390: upgrade libcrypto3/libssl3 to 3.5.6-r0+
 # Install Packages
-RUN apk update && apk add --no-cache --upgrade libpng && apk add --no-cache jq python3 py3-pip && \
+RUN apk update && apk add --no-cache --upgrade libpng libcrypto3 libssl3 musl musl-utils && apk add --no-cache jq python3 py3-pip && \
     python3 -m venv /venv && \
     . /venv/bin/activate && \
     pip install --no-cache-dir google-cloud-secret-manager google-auth google-api-core packaging && \

--- a/scripts/gcp-oidc/Dockerfile
+++ b/scripts/gcp-oidc/Dockerfile
@@ -1,12 +1,11 @@
-# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
-FROM eclipse-temurin@sha256:693c22ea458d62395bac47a2da405d0d18c77b205211ceec4846a550a37684b6
+# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
+FROM eclipse-temurin@sha256:ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
 
 LABEL "tee.launch_policy.allow_env_override"="API_TOKEN_SECRET_NAME,DEPLOYMENT_ENVIRONMENT,CORE_BASE_URL,OPTOUT_BASE_URL,DEBUG_MODE,SKIP_VALIDATIONS"
 LABEL "tee.launch_policy.log_redirect"="always"
 
-# CVE-2026-40200: upgrade musl/musl-utils to 1.2.5-r23+; CVE-2026-28390: upgrade libcrypto3/libssl3 to 3.5.6-r0+
 # Install Packages
-RUN apk update && apk add --no-cache --upgrade libpng libcrypto3 libssl3 musl musl-utils && apk add --no-cache jq python3 py3-pip && \
+RUN apk update && apk add --no-cache jq python3 py3-pip && \
     python3 -m venv /venv && \
     . /venv/bin/activate && \
     pip install --no-cache-dir google-cloud-secret-manager google-auth google-api-core packaging && \


### PR DESCRIPTION
## Summary

Fixes CVE-2026-40200 (HIGH severity) — musl libc arbitrary code execution and denial of service vulnerability.

Bumps all three eclipse-temurin Dockerfiles to the 2026-04-15 build of \`21-jre-alpine-3.23\`. Alpine 3.23 bundles all previously manually-upgraded packages at their latest non-vulnerable versions — the manual apk upgrades are now no-ops and have been removed:

| Package | Fixed version | CVE(s) |
|---|---|---|
| musl / musl-utils | 1.2.5-r23 | CVE-2026-40200 |
| libcrypto3 / libssl3 | 3.5.6-r0 | CVE-2026-28390 |
| libpng | 1.6.57-r0 | CVE-2026-22695, CVE-2026-25646 and others |

**Dockerfiles updated:** \`Dockerfile\`, \`scripts/azure-cc/Dockerfile\`, \`scripts/gcp-oidc/Dockerfile\`

**Jira:** https://thetradedesk.atlassian.net/browse/UID2-6950

## Test plan
- [ ] CI vulnerability scan passes with no HIGH/CRITICAL findings