### PR TITLE
UID2-6799 Update workflows that auto-merge PRs to bypass protection ruleset

### DIFF
--- a/.github/actions/update_operator_version/action.yaml
+++ b/.github/actions/update_operator_version/action.yaml
@@ -13,6 +13,9 @@ inputs:
   commit_sha:
     description: The commit SHA for committing the new version for pom.xml.
     default: ''
+  github_token:
+    description: Token used to merge the PR. Defaults to GITHUB_TOKEN if empty.
+    default: ''
 
 
 outputs:
@@ -104,6 +107,7 @@ runs:
       with:
         add: 'pom.xml version.json'
         message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
+        github_token: ${{ inputs.github_token }}
 
     - name: Commit pom.xml, version.json and set tag
       id: commit-and-tag
@@ -113,6 +117,7 @@ runs:
         add: 'pom.xml version.json'
         message: 'Released ${{ inputs.release_type }} version: ${{ steps.version.outputs.new_version }}'
         tag: v${{ steps.version.outputs.new_version }}
+        github_token: ${{ inputs.github_token }}
 
     - name: Get value of commit_sha
       id: get-commit-sha

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -25,6 +25,7 @@ jobs:
   start:
     name: Start Operator Build
     runs-on: ubuntu-latest
+    environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     outputs:
         new_version: ${{ steps.version.outputs.new_version }}
         commit_sha: ${{ steps.commit-and-tag.outputs.commit_sha }}
@@ -95,7 +96,8 @@ jobs:
         with:
           add: 'pom.xml version.json'
           message: 'Released ${{ env.RELEASE_TYPE }} version: ${{ steps.version.outputs.new_version }}'
-          tag: v${{ steps.version.outputs.new_version }} 
+          tag: v${{ steps.version.outputs.new_version }}
+          github_token: ${{ github.ref_protected && secrets.GH_MERGE_TOKEN || '' }}
 
   buildPublic:
     name: Public Operator

--- a/.github/workflows/publish-aws-nitro-eif.yaml
+++ b/.github/workflows/publish-aws-nitro-eif.yaml
@@ -38,6 +38,7 @@ jobs:
   start:
     name: Update Operator Version
     runs-on: ubuntu-latest
+    environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     steps:
       - name: Show Context
         shell: bash
@@ -45,9 +46,9 @@ jobs:
           printenv
           echo "$GITHUB_CONTEXT"
           echo "Commit SHA:" $COMMIT_SHA
-        env: 
+        env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -59,6 +60,7 @@ jobs:
           version_number_input: ${{ inputs.version_number_input }}
           image_tag_suffix: ${{ env.ENCLAVE_PROTOCOL }}
           commit_sha: ${{ inputs.commit_sha }}
+          github_token: ${{ github.ref_protected && secrets.GH_MERGE_TOKEN || '' }}
 
     outputs:
       new_version: ${{ steps.update_version.outputs.new_version }}

--- a/.github/workflows/publish-azure-cc-enclave-docker.yaml
+++ b/.github/workflows/publish-azure-cc-enclave-docker.yaml
@@ -60,6 +60,7 @@ jobs:
   buildImage:
     name: Build Image
     runs-on: ubuntu-latest
+    environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     permissions:
       contents: write
       security-events: write
@@ -84,6 +85,7 @@ jobs:
           version_number_input: ${{ inputs.version_number_input }}
           image_tag_suffix: ${{ env.ENCLAVE_PROTOCOL }}
           commit_sha: ${{ inputs.commit_sha }}
+          github_token: ${{ github.ref_protected && secrets.GH_MERGE_TOKEN || '' }}
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
+++ b/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
@@ -61,6 +61,7 @@ jobs:
   buildImage:
     name: Build Image
     runs-on: ubuntu-latest
+    environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     permissions:
       contents: write
       security-events: write
@@ -82,6 +83,7 @@ jobs:
           version_number_input: ${{ inputs.version_number_input }}
           image_tag_suffix: ${{ env.ENCLAVE_PROTOCOL }}
           commit_sha: ${{ inputs.commit_sha }}
+          github_token: ${{ github.ref_protected && secrets.GH_MERGE_TOKEN || '' }}
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/publish-public-operator-docker-image.yaml
+++ b/.github/workflows/publish-public-operator-docker-image.yaml
@@ -67,6 +67,7 @@ jobs:
       force_release: 'no' # Do not create a release for the component builds, will be created by the parent
       vulnerability_severity: ${{ inputs.vulnerability_severity }}
       java_version: 21
+      merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     secrets: inherit
 
   e2e:


### PR DESCRIPTION
**Updated Actions/Workflows**
`Update Operator Version`
- Added `github_token` input (default: '')
- Forward `github_token` to both `commit_pr_and_merge` calls

`Publish GCP OIDC Operator`
- Added `environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}` to `buildImage `job
- Pass `github_token` to `update_operator_version` action

`Publish Azure CC Operator`
- Added `environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}` to `buildImage` job
- Pass `github_token` to `update_operator_version` action

`Publish AWS Nitro EIFs`
- Added `environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}` to `start` job
- Pass `github_token` to `update_operator_version` action

`Publish Public Operator`
- Added `merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}` to the shared workflow call

The above changes are required to bypass the PR Approval ruleset

Related:
- https://github.com/IABTechLab/uid2-shared-actions/pull/219