### PR TITLE
UID2-7030: Upgrade gnutls + netty (CVE-2026-3833 + 4 netty CVEs)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -8,16 +8,6 @@ CVE-2025-66293 exp:2026-06-15
 # UID2-6481
 CVE-2025-68973 exp:2026-06-15
 
-# gnutls DoS vulnerability via crafted ClientHello - not impactful as gnutls is not used by our Java service
-# See: UID2-6655
-CVE-2026-1584 exp:2026-08-27
-# gnutls DoS vulnerability via DTLS zero-length record - not impactful as gnutls is not used by our Java service
-# See: UID2-7008
-CVE-2026-33845 exp:2026-11-04
-# gnutls DoS vulnerability via heap buffer overflow in DTLS handshake - not impactful as gnutls is not used by our Java service
-# See: UID2-7012
-CVE-2026-33846 exp:2026-11-05
-
 # jackson-core async parser DoS - not exploitable, services only use synchronous ObjectMapper API
 # See: UID2-6670
 GHSA-72hv-8253-57qq exp:2026-09-01
@@ -30,3 +20,12 @@ CVE-2026-25646 exp:2026-09-02
 # and the core libz library used by the JRE is unaffected. The zlib maintainer disputes this CVE.
 # See: UID2-6704
 CVE-2026-22184 exp:2026-09-09
+
+# CVE-2026-42577 — netty-transport-native-epoll DoS via RST on half-closed TCP connection.
+# Advisory: https://github.com/netty/netty/security/advisories/GHSA-rwm7-x88c-3g2p
+# Server-side bug; netty maintainers backported the fix only to 4.2.13.Final and we run on
+# vert.x 4 / netty 4.1.x. This service sits behind authenticated load balancers (mTLS / API
+# gateway) so anonymous external attackers cannot reach the netty epoll socket directly;
+# LB-level connection limits and idle timeouts further cap the blast radius. CVSS impact is
+# Availability only (C:N/I:N/A:H). Tracking via UID2-7035; revisit on vert.x 5 migration.
+CVE-2026-42577 exp:2026-06-08

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM eclipse-temurin@sha256:ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
 
 # For Amazon Corretto Crypto Provider
-RUN apk add --no-cache gcompat
+RUN apk add --no-cache gcompat && apk add --no-cache --upgrade gnutls
 
 WORKDIR /app
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <java.version>21</java.version>
-        <netty.version>4.1.132.Final</netty.version>
+        <netty.version>4.1.133.Final</netty.version>
     </properties>
 
 


### PR DESCRIPTION
## Summary

Bundled vulnerability fixes:

* **gnutls** upgraded to 3.8.13-r0 in the Docker image — fixes [CVE-2026-3833](https://avd.aquasec.com/nvd/cve-2026-3833) and obsoletes 3 prior `.trivyignore` entries (CVE-2026-1584 / 33845 / 33846), all of which are also fixed by 3.8.13-r0.
* **netty** bumped 4.1.132.Final → 4.1.133.Final — fixes CVE-2026-42583, CVE-2026-42579, CVE-2026-42584, CVE-2026-42587.
* **CVE-2026-42577** (`netty-transport-native-epoll` epoll DoS, server-side) suppressed in `.trivyignore` until 2026-06-08. No 4.1.x patch backported by upstream; service is behind authenticated LB so the attack surface is limited; CVSS impact is Availability-only.

Per-CVE Jira tickets:
* gnutls upgrade: [UID2-7030](https://thetradedesk.atlassian.net/browse/UID2-7030)
* CVE-2026-42583: [UID2-7031](https://thetradedesk.atlassian.net/browse/UID2-7031)
* CVE-2026-42579: [UID2-7032](https://thetradedesk.atlassian.net/browse/UID2-7032)
* CVE-2026-42584: [UID2-7033](https://thetradedesk.atlassian.net/browse/UID2-7033)
* CVE-2026-42587: [UID2-7034](https://thetradedesk.atlassian.net/browse/UID2-7034)
* CVE-2026-42577 (suppression): [UID2-7035](https://thetradedesk.atlassian.net/browse/UID2-7035)

## Test plan
- [ ] Trivy CI passes (or only flags expected suppressions)
- [ ] Build and unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)