### PR TITLE
UID2-7060: Fix CVE-2026-44431 & CVE-2026-44432 (urllib3) in scripts/aws

### DIFF
--- a/scripts/aws/requirements.txt
+++ b/scripts/aws/requirements.txt
@@ -1,4 +1,4 @@
 requests[socks]==2.32.3
 boto3==1.35.59
-urllib3==2.6.3
+urllib3==2.7.0
 PyYAML===6.0.2


### PR DESCRIPTION
## Summary
- Upgrades `urllib3` from 2.6.3 to 2.7.0 in `scripts/aws/requirements.txt` to fix CVE-2026-44431 and CVE-2026-44432.
- These CVEs were detected by the Trivy scan on the post-merge run of #2531: https://github.com/IABTechLab/uid2-operator/actions/runs/25718356966

## CVEs
- **CVE-2026-44431** (HIGH) — urllib3: Sensitive headers forwarded across origins in proxied low-level redirects
- **CVE-2026-44432** (HIGH) — urllib3: Decompression-bomb safeguards bypassed in parts of the streaming API

Both are fixed in urllib3 2.7.0.

## Impact assessment
`scripts/aws/requirements.txt` is consumed by the AWS deployment helpers under `scripts/aws/` (e.g. `ec2.py`), which run `requests` against the EC2 IMDS and the operator config server. The Python tooling here is a transitive consumer of urllib3, so upgrading the pinned version eliminates the finding and brings the deployment scripts onto the patched release.

## Jira
https://thetradedesk.atlassian.net/browse/UID2-7060 — original ticket already covers the same CVEs across `uid2-databricks`, `uid2docs`, `uid2-docs-preview`, and `uid2-monitoring-configuration`; this PR extends the rollout to `uid2-operator`.

## Test plan
- [ ] CI Trivy scan reports no urllib3 HIGH findings
- [ ] Build + unit tests pass