### PR TITLE
UID2-7002 Use 'publish-major' env instead of hardcoded approver list

### DIFF
--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -22,8 +22,16 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
+  check_major:
+    name: Check if major release
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.release_type == 'Major' && 'publish-major' || '' }}
+    steps:
+      - run: echo "Major release approved"
+
   start:
     name: Start Operator Build
+    needs: check_major
     runs-on: ubuntu-latest
     environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     outputs:
@@ -42,15 +50,6 @@ jobs:
           echo "vulnerability_severity=${{ inputs.vulnerability_severity || (github.event_name == 'schedule' && 'CRITICAL,HIGH') }}" >> $GITHUB_ENV
           echo "release_type=${RELEASE_TYPE}" >> $GITHUB_OUTPUT
           echo "vulnerability_severity=${VULNERABILITY_SEVERITY}" >> $GITHUB_OUTPUT
-      - name: Approve Major release
-        if: env.RELEASE_TYPE == 'Major'
-        uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1
-        with:
-          secret: ${{ github.token }}
-          approvers: atarassov-ttd,vishalegbert-ttd,sunnywu,clarkxuyang
-          minimum-approvals: 1
-          issue-title: Creating Major version of UID2-Operator
-
       - name: Show Context
         run: |
           printenv

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.release_type == 'Major' && 'publish-major' || '' }}
     steps:
-      - run: echo "Major release approved"
+      - run: echo "${{ inputs.release_type == 'Major' && 'Major release approved' || 'Skipped - not a Major release' }}"
 
   start:
     name: Start Operator Build

--- a/.github/workflows/publish-public-operator-docker-image.yaml
+++ b/.github/workflows/publish-public-operator-docker-image.yaml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.release_type == 'Major' && 'publish-major' || '' }}
     steps:
-      - run: echo "Major release approved"
+      - run: echo "${{ inputs.release_type == 'Major' && 'Major release approved' || 'Skipped - not a Major release' }}"
 
   image:
     name: Image

--- a/.github/workflows/publish-public-operator-docker-image.yaml
+++ b/.github/workflows/publish-public-operator-docker-image.yaml
@@ -47,15 +47,9 @@ jobs:
   check_major:
     name: Check if major release
     runs-on: ubuntu-latest
+    environment: ${{ inputs.release_type == 'Major' && 'publish-major' || '' }}
     steps:
-      - name: Approve Major release
-        if: inputs.release_type == 'Major'
-        uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1
-        with:
-          secret: ${{ github.token }}
-          approvers: atarassov-ttd,vishalegbert-ttd,sunnywu,clarkxuyang
-          minimum-approvals: 1
-          issue-title: Creating Major version of UID2-Operator
+      - run: echo "Major release approved"
 
   image:
     name: Image


### PR DESCRIPTION
Replaces `trstringer/manual-approval` steps in both `publish-all-operators.yaml` and `publish-public-operator-docker-image.yaml` with env-gated `check_major` jobs using the new `publish-major` environment.

Behaviour preserved:
  - Major release dispatched via `publish-all-operators.yaml` → 2 approval prompts (parent + leaf), same as before
  - Major denied at either gate blocks all downstream builds
  - Major dispatched directly on `publish-public-operator-docker-image.yaml` → 1 prompt (leaf)
  - Non-Major / scheduled patch → no gates