### PR TITLE
UID2-7109: upgrade gnutls in Azure CC and GCP OIDC Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
-FROM eclipse-temurin@sha256:ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
+# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
+FROM eclipse-temurin@sha256:704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
 
 # For Amazon Corretto Crypto Provider
-RUN apk add --no-cache gcompat && apk add --no-cache --upgrade gnutls
+RUN apk add --no-cache gcompat
 
 WORKDIR /app
 EXPOSE 8080

--- a/scripts/azure-cc/Dockerfile
+++ b/scripts/azure-cc/Dockerfile
@@ -2,7 +2,7 @@
 FROM eclipse-temurin@sha256:ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
 
 # Install necessary packages and set up virtual environment
-RUN apk update && apk add --no-cache jq python3 py3-pip && \
+RUN apk update && apk add --no-cache --upgrade gnutls && apk add --no-cache jq python3 py3-pip && \
     python3 -m venv /venv && \
     . /venv/bin/activate && \
     pip install --no-cache-dir requests azure-identity azure-keyvault-secrets && \

--- a/scripts/azure-cc/Dockerfile
+++ b/scripts/azure-cc/Dockerfile
@@ -1,8 +1,8 @@
-# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
-FROM eclipse-temurin@sha256:ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
+# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
+FROM eclipse-temurin@sha256:704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
 
 # Install necessary packages and set up virtual environment
-RUN apk update && apk add --no-cache --upgrade gnutls && apk add --no-cache jq python3 py3-pip && \
+RUN apk update && apk add --no-cache jq python3 py3-pip && \
     python3 -m venv /venv && \
     . /venv/bin/activate && \
     pip install --no-cache-dir requests azure-identity azure-keyvault-secrets && \

--- a/scripts/gcp-oidc/Dockerfile
+++ b/scripts/gcp-oidc/Dockerfile
@@ -1,11 +1,11 @@
-# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
-FROM eclipse-temurin@sha256:ad0cdd9782db550ca7dde6939a16fd850d04e683d37d3cff79d84a5848ba6a5a
+# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
+FROM eclipse-temurin@sha256:704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
 
 LABEL "tee.launch_policy.allow_env_override"="API_TOKEN_SECRET_NAME,DEPLOYMENT_ENVIRONMENT,CORE_BASE_URL,OPTOUT_BASE_URL,DEBUG_MODE,SKIP_VALIDATIONS"
 LABEL "tee.launch_policy.log_redirect"="always"
 
 # Install Packages
-RUN apk update && apk add --no-cache --upgrade gnutls && apk add --no-cache jq python3 py3-pip && \
+RUN apk update && apk add --no-cache jq python3 py3-pip && \
     python3 -m venv /venv && \
     . /venv/bin/activate && \
     pip install --no-cache-dir google-cloud-secret-manager google-auth google-api-core packaging && \

--- a/scripts/gcp-oidc/Dockerfile
+++ b/scripts/gcp-oidc/Dockerfile
@@ -5,7 +5,7 @@ LABEL "tee.launch_policy.allow_env_override"="API_TOKEN_SECRET_NAME,DEPLOYMENT_E
 LABEL "tee.launch_policy.log_redirect"="always"
 
 # Install Packages
-RUN apk update && apk add --no-cache jq python3 py3-pip && \
+RUN apk update && apk add --no-cache --upgrade gnutls && apk add --no-cache jq python3 py3-pip && \
     python3 -m venv /venv && \
     . /venv/bin/activate && \
     pip install --no-cache-dir google-cloud-secret-manager google-auth google-api-core packaging && \


### PR DESCRIPTION
## Summary

Bumps the pinned `eclipse-temurin` base image digest from `ad0cdd97` (2026-04-15) to `704db3c4` (2026-05-08), which ships **gnutls 3.8.13-r0** — fixing all 5 gnutls CVEs directly in the base image.

Also removes the manual `apk add --no-cache --upgrade gnutls` line from `Dockerfile` (no longer needed), and simplifies the apk step to just `apk add --no-cache gcompat`.

| CVE | Severity | Title |
|-----|----------|-------|
| CVE-2026-33845 | CRITICAL | GnuTLS: Denial of Service via DTLS zero-length |
| CVE-2026-42010 | CRITICAL | gnutls: Authentication Bypass via NUL Character in cert |
| CVE-2026-33846 | HIGH | GnuTLS: Denial of Service via heap buffer overflow |
| CVE-2026-3833 | HIGH | GnuTLS: Policy bypass due to case-sensitive |
| CVE-2026-42011 | HIGH | gnutls: Security bypass due to incorrect name |

Verified via Alpine 3.23 security DB (`secdb.alpinelinux.org`): gnutls 3.8.13-r0 fixes all CVEs listed above. New image published 2026-05-08, after the 2026-04-29 fix release.

Follows the workflow from [UID2-6951](https://thetradedesk.atlassian.net/browse/UID2-6951): bump digest instead of layering manual `apk upgrade` lines.

Companion PRs for repos sharing the same base image:
- [uid2-alb-log-processor #41](https://github.com/UnifiedID2/uid2-alb-log-processor/pull/41)
- [uid2-validator #331](https://github.com/UnifiedID2/uid2-validator/pull/331)
- [uid2-snowflake #302](https://github.com/UnifiedID2/uid2-snowflake/pull/302)

Jira: https://thetradedesk.atlassian.net/browse/UID2-7109

## Test plan

- [ ] CI Trivy scan passes with no CRITICAL/HIGH findings for gnutls
- [ ] Azure CC and GCP OIDC build jobs complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)