### PR TITLE
UID2-7162 Azure CC: Wait until SKR is running before starting Operator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.70.110</version>
+    <version>5.70.111-alpha-259-SNAPSHOT</version>
   
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/scripts/azure-cc/azr.py
+++ b/scripts/azure-cc/azr.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import socket
 import time
 from typing import Dict
 import sys
@@ -25,6 +26,8 @@ class AZR(ConfidentialCompute):
     default_optout_endpoint = f"https://optout-{env_name}.uidapi.com".lower()
 
     FINAL_CONFIG = "/tmp/final-config.json"
+    SKR_HOST = "localhost"
+    SKR_PORT = 9000
 
     def __init__(self):
         super().__init__()
@@ -118,27 +121,25 @@ class AZR(ConfidentialCompute):
         self.run_command(java_command, separate_process=False)
 
     def _validate_auxiliaries(self):
-        logging.info("Waiting for sidecar ...")
-
+        # Block JVM start until SKR is accepting TCP connections on :9000.
+        # Without this, the first attestation calls race the sidecar's HTTP
+        # server warmup and Core sees BAD_PAYLOAD (signature on a
+        # half-bootstrapped MAA token).
         MAX_RETRIES = 15
-        PING_URL = "http://169.254.169.254/ping"
         delay = 1
+
+        logging.info(f"Waiting for SKR sidecar on {AZR.SKR_HOST}:{AZR.SKR_PORT} ...")
 
         for attempt in range(1, MAX_RETRIES + 1):
             try:
-                response = requests.get(PING_URL, timeout=5)
-                if response.status_code in [200, 204]:
-                    logging.info("Sidecar started successfully.")
+                with socket.create_connection((AZR.SKR_HOST, AZR.SKR_PORT), timeout=5):
+                    logging.info("SKR sidecar is ready.")
                     return
-                else:
-                    logging.warning(
-                        f"Attempt {attempt}: Unexpected status code {response.status_code}. Response: {response.text}"
-                    )
-            except Exception as e:
-                logging.info(f"Attempt {attempt}: Error during request - {e}")
+            except OSError as e:
+                logging.info(f"Attempt {attempt}: SKR sidecar not ready - {e}")
 
             if attempt == MAX_RETRIES:
-                raise RuntimeError(f"Unable to detect sidecar running after {MAX_RETRIES} attempts. Exiting.")
+                raise RuntimeError(f"SKR sidecar not ready after {MAX_RETRIES} attempts. Exiting.")
 
             logging.info(f"Retrying in {delay} seconds... (Attempt {attempt}/{MAX_RETRIES})")
             time.sleep(delay)
@@ -152,10 +153,13 @@ class AZR(ConfidentialCompute):
             self.validate_configuration()
         self.__create_final_config()
         self._setup_auxiliaries()
+        self._validate_auxiliaries()
         self.__run_operator()
 
     def _setup_auxiliaries(self) -> None:
-        """ setup auxiliary services are running."""
+        # No-op for Azure CC: the SKR sidecar is a separate container declared
+        # in the ARM template and started by Azure ACI alongside this one. We
+        # only need to wait for it (see _validate_auxiliaries), not start it.
         pass
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Summary**
Wait for the SKR sidecar to accept TCP connections on `localhost:9000` before launching the JVM in Azure CC operator startup. Intended to close a startup race that caused `BAD_PAYLOAD` attestation failures.

**Background**
- While testing the SKR 2.3 → 2.14 upgrade, uid2-core integ logged `BAD_PAYLOAD / "Cannot verify payload with the signature"` attestation failures on operator start, immediately followed by successful attestation a few seconds later. 
- Likely cause: Operator was starting before the SKR sidecar's was running

**Changes**
  - `_validate_auxiliaries`: rewrite to TCP-probe `localhost:9000` with the same retry/backoff structure as before. 15 attempts, exponential delay, fatal on timeout.
  - `run_compute`: call `_validate_auxiliaries()` between `_setup_auxiliaries()` and `__run_operator()`. Matches the AWS pattern.
  - `_setup_auxiliaries`: add a comment explaining why it's intentionally a no-op for Azure CC (SKR is started by ACI, not by us).
  - Add `SKR_HOST` / `SKR_PORT` as class-level constants on `AZR`.

## Verification

Deployed to Azure integ as snapshot `5.70.111-alpha-259-SNAPSHOT`. Startup log shows the new path executing cleanly:
```
  INFO:root:Start Azure
  ...
  INFO:root:Waiting for SKR sidecar on localhost:9000 ...
  INFO:root:SKR sidecar is ready.
  ...
  09:42:27.669 ... Startup in 11576 ms
```