### PR TITLE
UID2-7162 Upgrade SKR image to 2.14 for Azure AKS

### DIFF
--- a/scripts/azure-aks/deployment/operator.yaml
+++ b/scripts/azure-aks/deployment/operator.yaml
@@ -17,7 +17,7 @@ spec:
         microsoft.containerinstance.virtualnode.injectdns: "false"
     spec:
       containers:
-        - image: "mcr.microsoft.com/aci/skr:2.7"
+        - image: "mcr.microsoft.com/aci/skr:2.14"
           imagePullPolicy: Always
           name: skr
           resources:


### PR DESCRIPTION
Upgrade SKR image to 2.14 in the Azure AKS deployment, mirroring https://github.com/IABTechLab/uid2-operator/pull/2559.