### PR TITLE
chore: upgrade GitHub Actions from Node 20 to Node 24

### DIFF
--- a/.github/actions/build_ami/action.yaml
+++ b/.github/actions/build_ami/action.yaml
@@ -56,7 +56,7 @@ runs:
         GITHUB_CONTEXT: ${{ toJson(github) }}
 
     - name: Checkout full history
-      uses: actions/checkout@v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Get EIF for Release ${{ inputs.operator_release }}
       uses: ./.github/actions/download_release_artifact
@@ -190,7 +190,7 @@ runs:
         ls -al
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.identity_scope }}_AMI_measurement
         path: ./scripts/aws/uid2-operator-ami/${{ inputs.identity_scope }}_AMI_measurement.txt

--- a/.github/actions/build_aws_eif/action.yaml
+++ b/.github/actions/build_aws_eif/action.yaml
@@ -31,7 +31,7 @@ runs:
 
   steps:
     - name: Checkout full history at commit sha ${{ inputs.commit_sha }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         ref: ${{ inputs.commit_sha }}
         # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.

--- a/.github/actions/build_eks_docker_image/action.yaml
+++ b/.github/actions/build_eks_docker_image/action.yaml
@@ -39,7 +39,7 @@ runs:
 
   steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Make output dir
       shell: bash
@@ -112,7 +112,7 @@ runs:
         df -h
 
     - name: Log in to the Docker container registry
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -120,14 +120,14 @@ runs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+      uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-eks-${{ inputs.identity_scope }}
         tags: |
           type=raw,value=${{ steps.versionNumber.outputs.VERSION_NUMBER }}.${{ github.run_number }}
 
     - name: Build and export to Docker
-      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: ${{ inputs.artifacts_output_dir }}
         load: true
@@ -140,7 +140,7 @@ runs:
 
     - name: Push to Docker
       id: push-to-docker
-      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: ${{ inputs.artifacts_output_dir }}
         push: true

--- a/.github/actions/download_release_artifact/action.yaml
+++ b/.github/actions/download_release_artifact/action.yaml
@@ -27,7 +27,7 @@ runs:
   steps:
     - name: Get Artifact Ids
       id: get_asset_id
-      uses: actions/github-script@v7
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         github-token: ${{ inputs.github_token }}
         result-encoding: string

--- a/.github/actions/update_operator_version/action.yaml
+++ b/.github/actions/update_operator_version/action.yaml
@@ -65,14 +65,14 @@ runs:
         IS_RELEASE: ${{ steps.checkRelease.outputs.is_release }}
 
     - name: Checkout full history on Main
-      uses: actions/checkout@v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       if: ${{ inputs.version_number_input == '' }}
       with:
         # git-restore-mtime requires full git history. The default fetch-depth value (1) creates a shallow checkout.
         fetch-depth: 0
 
     - name: Checkout full history at tag v${{ inputs.version_number_input }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       if: ${{ inputs.version_number_input != '' }}
       with:
         ref: v${{ inputs.version_number_input }}

--- a/.github/workflows/build-uid2-ami.yaml
+++ b/.github/workflows/build-uid2-ami.yaml
@@ -38,7 +38,7 @@ jobs:
       enclave_id: ${{ steps.buildAMI.outputs.enclave_id }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build UID2 Operator AMI
         id: buildAMI
@@ -78,7 +78,7 @@ jobs:
         enclave_id: ${{ steps.buildAMI.outputs.enclave_id }}
       steps:
         - name: Checkout repo
-          uses: actions/checkout@v4
+          uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
         - name: Pre-cleanup
           shell: bash
@@ -123,26 +123,26 @@ jobs:
     needs: [buildUID2, testUID2Ami, testEUIDAmi]
     steps:
       - name: Download UID2 artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: uid2_AMI_measurement
           path: ./artifacts
 
       - name: Download EUID artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: euid_AMI_measurement
           path: ./artifacts
 
       - name: Delete staging artifacts
-        uses: geekyeggo/delete-artifact@b54d29a59e55046d1f7fc8226cdda507e6b9cf62 # v5
+        uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # v6.0.0
         with: 
           name: |
             uid2_AMI_measurement
             euid_AMI_measurement
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aws-ami-ids-${{ needs.buildUID2.outputs.version_number }}
           path: ./artifacts/

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -64,7 +64,7 @@ jobs:
           release_type: ${{ inputs.release_type }}
     
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -155,61 +155,61 @@ jobs:
     needs: [start, buildPublic, buildGCP, buildAzure, buildAWS, buildAMI]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Download public manifest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: public-image-*
           path: ./manifests/public_operator
 
       - name: Download GCP manifest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: gcp-oidc-enclave-ids-*
           path: ./manifests/gcp_oidc_operator
 
       - name: Download Azure CC manifest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: azure-cc-enclave-id-*
           path: ./manifests/azure_cc_operator
 
       - name: Download Azure AKS manifest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: azure-aks-enclave-id-*
           path: ./manifests/azure_aks_operator
 
       - name: Download EIF manifest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: 'aws-eif-enclave-ids-*'
           path: ./manifests/aws_eif
 
       - name: Download AWS AMI manifest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: 'aws-ami-ids-*'
           path: ./manifests/aws_ami
 
       - name: Download Deployment Files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: '*-deployment-files-*'
           path: ./deployment
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: uid2-operator-release-${{ needs.start.outputs.new_version }}-manifests
           path: ./manifests
 
       - name: Build changelog
         id: changelog
-        uses: mikepenz/release-changelog-builder-action@32e3c96f29a6532607f638797455e9e98cfc703d # v4
+        uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 # v6.2.2
         with:
           toTag: v${{ needs.start.outputs.new_version }}
           configurationJson: |
@@ -230,7 +230,7 @@ jobs:
           (cd manifests && zip -r ../uid2-operator-release-manifests-${{ needs.start.outputs.new_version }}.zip .)
 
       - name: Create draft release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: v${{ needs.start.outputs.new_version }}
           body: ${{ steps.changelog.outputs.changelog }}

--- a/.github/workflows/publish-aws-eks-nitro-enclave-docker.yaml
+++ b/.github/workflows/publish-aws-eks-nitro-enclave-docker.yaml
@@ -37,7 +37,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build Docker Image for EKS Pod
         id: build_docker_image_uid
@@ -65,7 +65,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build Docker Image for EKS Pod
         id: build_docker_image_euid
@@ -128,7 +128,7 @@ jobs:
           echo "Enclave ID (maybe shared by other images): " ${{ needs.buildEUIDImage.outputs.enclave_id }} >> ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/manifests/aws-eks-euid-enclave-id-${{ needs.buildEUIDImage.outputs.image_tag }}.txt
 
       - name: Save Manifests as build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aws-eks-enclave-ids-${{ needs.buildUID2Image.outputs.image_tag }}
           path: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/manifests

--- a/.github/workflows/publish-aws-nitro-eif.yaml
+++ b/.github/workflows/publish-aws-nitro-eif.yaml
@@ -50,7 +50,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Update Operator Version
         id: update_version
@@ -74,7 +74,7 @@ jobs:
     needs: start
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build UID2 AWS EIF
         id: build_uid2_eif
@@ -93,7 +93,7 @@ jobs:
           df -h
 
       - name: Save UID2 eif artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aws-uid2-deployment-files-${{ needs.start.outputs.new_version }}
           path: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/uid2
@@ -113,7 +113,7 @@ jobs:
     needs: start
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build EUID AWS EIF
         id: build_euid_eif
@@ -132,7 +132,7 @@ jobs:
           df -h
 
       - name: Save EUID eif artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aws-euid-deployment-files-${{ needs.start.outputs.new_version }}
           path: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/euid
@@ -157,12 +157,12 @@ jobs:
           df -h  
 
       - name: Download UID2 artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/uid2
 
       - name: Download EUID artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/euid
 
@@ -173,7 +173,7 @@ jobs:
           echo ${{ needs.buildEUIDEIF.outputs.euid_enclave_id }} >> ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/manifests/aws-euid-enclave-id-${{ needs.start.outputs.new_version }}.txt
 
       - name: Save Manifests as build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aws-eif-enclave-ids-${{ needs.start.outputs.new_version }}
           path: ${{ env.ARTIFACTS_BASE_OUTPUT_DIR }}/manifests
@@ -182,7 +182,7 @@ jobs:
       - name: Build changelog
         id: github_release
         if: ${{ inputs.version_number_input == '' && needs.start.outputs.is_release == 'true' }}
-        uses: mikepenz/release-changelog-builder-action@32e3c96f29a6532607f638797455e9e98cfc703d # v4
+        uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 # v6.2.2
         with:
           configurationJson: |
             {
@@ -194,7 +194,7 @@ jobs:
 
       - name: Create release
         if: ${{ inputs.version_number_input == '' && needs.start.outputs.is_release == 'true' }}
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: ${{ needs.start.outputs.new_version }}
           body: ${{ steps.github_release.outputs.changelog }}

--- a/.github/workflows/publish-azure-cc-enclave-docker.yaml
+++ b/.github/workflows/publish-azure-cc-enclave-docker.yaml
@@ -75,7 +75,7 @@ jobs:
       tags: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Update Operator Version
         id: update_version
@@ -88,7 +88,7 @@ jobs:
           github_token: ${{ github.ref_protected && secrets.GH_MERGE_TOKEN || '' }}
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -103,7 +103,7 @@ jobs:
           cp scripts/confidential_compute.py ${{ env.DOCKER_CONTEXT_PATH }}/
 
       - name: Log in to the Docker container registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -111,14 +111,14 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ steps.update_version.outputs.image_tag }}
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{ env.DOCKER_CONTEXT_PATH }}
           load: true
@@ -141,7 +141,7 @@ jobs:
           hide-progress: true
 
       - name: Upload Trivy scan report to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -157,7 +157,7 @@ jobs:
 
       - name: Push to Docker
         id: push-to-docker
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{ env.DOCKER_CONTEXT_PATH }}
           push: true
@@ -174,7 +174,7 @@ jobs:
     needs: buildImage
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Azure CLI
         uses: ./.github/actions/install_az_cli
@@ -193,14 +193,14 @@ jobs:
           bash ./scripts/azure-cc/deployment/generate-deployment-artifacts.sh
 
       - name: Upload deployment artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: azure-cc-deployment-files-${{ needs.buildImage.outputs.jar_version }}
           path: ${{ env.ARTIFACTS_OUTPUT_DIR }}
           if-no-files-found: error
 
       - name: Upload manifest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: azure-cc-enclave-id-${{ needs.buildImage.outputs.jar_version }}
           path: ${{ env.MANIFEST_OUTPUT_DIR }}
@@ -222,7 +222,7 @@ jobs:
     needs: buildImage
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Azure CLI
         uses: ./.github/actions/install_az_cli
@@ -241,14 +241,14 @@ jobs:
           bash ./scripts/azure-aks/deployment/generate-deployment-artifacts.sh
 
       - name: Upload deployment artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: azure-aks-deployment-files-${{ needs.buildImage.outputs.jar_version }}
           path: ${{ env.ARTIFACTS_OUTPUT_DIR }}
           if-no-files-found: error
 
       - name: Upload manifest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: azure-aks-enclave-id-${{ needs.buildImage.outputs.jar_version }}
           path: ${{ env.MANIFEST_OUTPUT_DIR }}

--- a/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
+++ b/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
@@ -73,7 +73,7 @@ jobs:
       image_tag: ${{ steps.update_version.outputs.image_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Update Operator Version
         id: update_version
@@ -86,7 +86,7 @@ jobs:
           github_token: ${{ github.ref_protected && secrets.GH_MERGE_TOKEN || '' }}
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -101,7 +101,7 @@ jobs:
           cp scripts/confidential_compute.py ${{ env.DOCKER_CONTEXT_PATH }}/
 
       - name: Log in to the Docker container registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -109,7 +109,7 @@ jobs:
 
       - name: Authenticate with Google Cloud
         id: gcp_auth
-        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           token_format: access_token
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER_ID }}
@@ -117,7 +117,7 @@ jobs:
           access_token_lifetime: 300s
 
       - name: Log in to the GCP Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.GCP_REGISTRY }}
           username: oauth2accesstoken
@@ -125,7 +125,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -133,7 +133,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for GCP image
         id: meta-gcp
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.GCP_REGISTRY }}/${{ env.GCP_GAR_PROJECT }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -141,7 +141,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for all Docker images
         id: meta-all
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -150,7 +150,7 @@ jobs:
             type=raw,value=${{ steps.update_version.outputs.new_version }}-${{ env.ENCLAVE_PROTOCOL }}
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{ env.DOCKER_CONTEXT_PATH }}
           load: true
@@ -171,7 +171,7 @@ jobs:
 
       - name: Push to Docker
         id: push-to-docker
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{ env.DOCKER_CONTEXT_PATH }}
           push: true
@@ -192,14 +192,14 @@ jobs:
           bash ./scripts/gcp-oidc/generate-deployment-artifacts.sh
 
       - name: Upload deployment artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gcp-oidc-deployment-files-${{ steps.update_version.outputs.new_version }}
           path: ${{ env.ARTIFACTS_OUTPUT_DIR }}
           if-no-files-found: error
 
       - name: Upload manifest artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gcp-oidc-enclave-ids-${{ steps.update_version.outputs.new_version }}
           path: ${{ env.MANIFEST_OUTPUT_DIR }}
@@ -213,7 +213,7 @@ jobs:
       - name: Build changelog
         id: github_release
         if: ${{ inputs.version_number_input == '' && steps.update_version.outputs.is_release == 'true' }}
-        uses: mikepenz/release-changelog-builder-action@32e3c96f29a6532607f638797455e9e98cfc703d # v4
+        uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 # v6.2.2
         with:
           configurationJson: |
             {
@@ -225,7 +225,7 @@ jobs:
 
       - name: Create release
         if: ${{ inputs.version_number_input == '' && steps.update_version.outputs.is_release == 'true' }}
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: ${{ steps.update_version.outputs.new_version }}
           body: ${{ steps.github_release.outputs.changelog }}

--- a/.github/workflows/publish-public-operator-docker-image.yaml
+++ b/.github/workflows/publish-public-operator-docker-image.yaml
@@ -93,7 +93,7 @@ jobs:
           echo $IMAGE > image-details/public-image-$IMAGE_TAG.json
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: public-image-${{ needs.image.outputs.image_tag }}
           path: image-details/


### PR DESCRIPTION
Node 20 is being deprecated on GitHub Actions runners. Starting **June 16, 2026**, runners will use Node 24 by default.

This PR upgrades outdated action references in this repo to the latest released version that ships Node 24 support, pinned to its commit SHA. Each action's node version is determined by reading its `action.yml` at the pinned ref.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
