### PR TITLE
UID2-6520 Enforce min enclave size for AWS Nitro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-operator</artifactId>
-    <version>5.70.135</version>
+    <version>5.70.136-alpha-222-SNAPSHOT</version>
   
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/scripts/aws/README.md
+++ b/scripts/aws/README.md
@@ -41,8 +41,8 @@ UID2 Operator application reads configuration from [AWS Secrets Manager](https:/
 ```
 {
   "api_token": "<your-operator-key>",
-  "enclave_cpu_count": "6",
-  "enclave_memory_mb": "24000",
+  "enclave_cpu_count": 6,
+  "enclave_memory_mb": 24576,
   "clients_metadata_path": "https://core-integ.uidapi.com/clients/refresh",
   "salts_metadata_path": "https://core-integ.uidapi.com/salt/refresh",
   "keysets_metadata_path": "https://core-integ.uidapi.com/key/keyset/refresh",
@@ -54,7 +54,6 @@ UID2 Operator application reads configuration from [AWS Secrets Manager](https:/
 ```
 Important Notes:
 - above fields are all required
-- enclave_cpu_count/enclave_memory_mb are currently not customizable, modification to these fields will be ignored
 - `core-integ` is integration test endpoint; use `core-prod` when ready for production usage
 - you might need to replicate secret after creation to use it in other regions
 

--- a/scripts/aws/ec2.py
+++ b/scripts/aws/ec2.py
@@ -72,6 +72,10 @@ DEFAULT_BASE_URLS = {
 
 class EC2(ConfidentialCompute):
 
+    # Minimum enclave resources we support
+    MIN_ENCLAVE_CPU_COUNT = 6
+    MIN_ENCLAVE_MEMORY_MB = 24576  # 24 GB
+
     def __init__(self):
         super().__init__()
 
@@ -113,11 +117,15 @@ class EC2(ConfidentialCompute):
         
     def __validate_aws_specific_config(self):
         if "enclave_memory_mb" in self.configs or "enclave_cpu_count" in self.configs:
+            """
+            Verify that CPU and Memory reserved for the enclave meet our minimum requirements.
+            Note: nitro-cli will fail if we attempt to launch an enclave larger than what the allocator reserved, hence the upper bound checks
+            """
             max_capacity = self.__get_max_capacity()
-            if self.configs.get('enclave_memory_mb') < 11000 or self.configs.get('enclave_memory_mb') > max_capacity.get('enclave_memory_mb'):
-                raise ConfigurationValueError(self.__class__.__name__, f"enclave_memory_mb must be in range 11000 and {max_capacity.get('enclave_memory_mb')}")
-            if self.configs.get('enclave_cpu_count') < 2 or self.configs.get('enclave_cpu_count') > max_capacity.get('enclave_cpu_count'):
-                raise ConfigurationValueError(self.__class__.__name__, f"enclave_cpu_count must be in range 2 and {max_capacity.get('enclave_cpu_count')}")
+            if self.configs.get('enclave_memory_mb') < self.MIN_ENCLAVE_MEMORY_MB or self.configs.get('enclave_memory_mb') > max_capacity.get('enclave_memory_mb'):
+                raise ConfigurationValueError(self.__class__.__name__, f"enclave_memory_mb must be in range {self.MIN_ENCLAVE_MEMORY_MB} and {max_capacity.get('enclave_memory_mb')}")
+            if self.configs.get('enclave_cpu_count') < self.MIN_ENCLAVE_CPU_COUNT or self.configs.get('enclave_cpu_count') > max_capacity.get('enclave_cpu_count'):
+                raise ConfigurationValueError(self.__class__.__name__, f"enclave_cpu_count must be in range {self.MIN_ENCLAVE_CPU_COUNT} and {max_capacity.get('enclave_cpu_count')}")
         
     def _set_confidential_config(self, secret_identifier: str) -> None:
         """Fetches a secret value from AWS Secrets Manager and adds defaults"""


### PR DESCRIPTION
Increase minimum enclave CPU/memory to `6CPU` and `24GB` respectively to keep consistent with our requirements.

Update README and comments for clarity.