### PR TITLE
UID2-7251: bump netty to 4.1.135.Final to fix 4 HIGH CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <java.version>21</java.version>
-        <netty.version>4.1.133.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
     </properties>
 
 


### PR DESCRIPTION
## What

Bumps `netty.version` from `4.1.133.Final` → `4.1.135.Final` in the operator pom.

## Why

The Trivy scan in the operator publish workflows (e.g. `publish-azure-cc-enclave-docker`) fails on **4 HIGH** netty CVEs in the operator jar:

| Library | CVE | Fixed in |
|---------|-----|----------|
| `io.netty:netty-handler` | CVE-2026-44249 (IPv6 subnet filter bypass) | 4.1.135.Final |
| `io.netty:netty-handler` | CVE-2026-45416 (SNI handler 16 MiB pre-alloc) | 4.1.135.Final |
| `io.netty:netty-resolver-dns` | CVE-2026-45674 (DNS cache poisoning) | 4.1.135.Final |
| `io.netty:netty-resolver-dns` | CVE-2026-47691 (insufficient bailiwick validation) | 4.1.135.Final |

The operator pins netty **directly** via the `netty.version` property + `netty-bom` import, so it does **not** inherit the version from uid2-shared — the bump has to happen here. uid2-shared PR #614 bumped netty to `4.1.133.Final`, which is below the fix version and does not clear the scan.

## Verification

- `mvn dependency:tree -Dincludes=io.netty` confirms all `netty-4.1.x` artifacts resolve to `4.1.135.Final` (netty-bom forces them).
- `mvn clean compile` → BUILD SUCCESS against Vert.x 4.5.21.
- These are the only 4 vulns in the scan (alpine OS, sources jar, and all python-pkg targets report 0), so this clears the scan entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)