### PR TITLE
chore: upgrade IABTechLab/uid2-shared-actions from v2 to v3

### DIFF
--- a/.github/workflows/check-stable-dependency.yaml
+++ b/.github/workflows/check-stable-dependency.yaml
@@ -3,5 +3,5 @@ on: [pull_request, workflow_dispatch]
 
 jobs:
   check_dependency:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-check-stable-dependency.yaml@v2
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-check-stable-dependency.yaml@v3
     secrets: inherit

--- a/.github/workflows/check-stable-dependency.yaml
+++ b/.github/workflows/check-stable-dependency.yaml
@@ -1,6 +1,9 @@
 name: Check Stable Dependencies 
 on: [pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   check_dependency:
     uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-check-stable-dependency.yaml@v3


### PR DESCRIPTION
This PR bumps all `IABTechLab/uid2-shared-actions` references in this repo from the `@v2` major tag to `@v3`.
