### PR TITLE
UID2-7279: suppress CVE-2026-45447 (libcrypto3); extend CVE-2026-42577 expiry

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -28,4 +28,10 @@ CVE-2026-22184 exp:2026-09-09
 # gateway) so anonymous external attackers cannot reach the netty epoll socket directly;
 # LB-level connection limits and idle timeouts further cap the blast radius. CVSS impact is
 # Availability only (C:N/I:N/A:H). Tracking via UID2-7035; revisit on vert.x 5 migration.
-CVE-2026-42577 exp:2026-06-08
+CVE-2026-42577 exp:2026-09-11
+
+# CVE-2026-45447 — libcrypto3 PKCS#7/S/MIME memory corruption in Alpine base image.
+# uid2-operator is a pure Java service; the JVM uses JSSE for TLS, not the native
+# libcrypto3 C library. No JNI or OpenSSL calls in source. Attack vector (malformed
+# PKCS#7/S/MIME parsing) is not reachable from this service. See: UID2-7279
+CVE-2026-45447 exp:2026-07-11


### PR DESCRIPTION
## Summary

- **CVE-2026-45447 suppression** (UID2-7279): add libcrypto3 to `.trivyignore` with `exp:2026-07-11`. libcrypto3 is present in the Alpine base image but the JVM uses JSSE for TLS — not the native C library. No JNI or OpenSSL calls in source.
- **CVE-2026-42577 expiry extended**: `2026-06-08` → `2026-09-11` (3 months; no 4.1.x fix available, vert.x 5 migration pending per UID2-7035).

## Jira
- [UID2-7279](https://thetradedesk.atlassian.net/browse/UID2-7279)

## Test plan
- [ ] CI vulnerability scan passes (CVE-2026-45447 suppressed, CVE-2026-42577 no longer expired)