### PR TITLE
UID2-6385/UID2-6481: .trivyignore cleanup — extend CVE-2025-66293, remove CVE-2025-68973

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,11 +2,12 @@
 # See https://aquasecurity.github.io/trivy/v0.35/docs/vulnerability/examples/filter/ 
 # for more details
 
-# UID2-6385
-CVE-2025-66293 exp:2026-06-15
-
-# UID2-6481
-CVE-2025-68973 exp:2026-06-15
+# libpng OOB read in png_image_read_composite - uid2-operator is a pure Java service
+# that never calls into libpng's simplified PNG processing API; the JVM does not use
+# libpng for image handling. Fix is available in Alpine 3.23 >= 1.6.53-r0 but the
+# pinned eclipse-temurin image has not yet been rebuilt with it (tracked alongside
+# sibling CVE-2026-25646 which shares the same base-image lag). See: UID2-6385
+CVE-2025-66293 exp:2026-09-15
 
 # jackson-core async parser DoS - not exploitable, services only use synchronous ObjectMapper API
 # See: UID2-6670


### PR DESCRIPTION
## Summary

Routine `.trivyignore` expiry cleanup — both entries expired on 2026-06-15.

- **CVE-2025-66293** (libpng OOB read, HIGH): Extended expiry to **2026-09-15**. Fix is available in Alpine 3.23 ≥ 1.6.53-r0 but the pinned `eclipse-temurin:21-jre-alpine-3.23` image has not yet been rebuilt with it. Improved comment to clarify uid2-operator is a pure Java service that never invokes libpng's PNG processing API (tracked alongside sibling CVE-2026-25646 which already has a Sep expiry). Jira: UID2-6385.

- **CVE-2025-68973** (GnuPG OOB write, HIGH): **Removed** suppression. `gnupg 2.4.9-r0` (the patched version) has been in Alpine 3.23 since January 2026, and the pinned image was last rebuilt in May 2026 — the fix is present in the current image. uid2-operator is a pure Java service that never invokes GnuPG, making this doubly moot. Jira: UID2-6481.

## Test plan

- [ ] Trivy vulnerability scan passes in CI
- [ ] No new CVEs introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)