### PR TITLE
UID2-7335: upgrade libexpat to patch CVE-2026-45186 (DoS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM eclipse-temurin@sha256:704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
 
 # For Amazon Corretto Crypto Provider
-RUN apk add --no-cache gcompat
+RUN apk add --no-cache --upgrade gcompat libexpat
 
 WORKDIR /app
 EXPOSE 8080


### PR DESCRIPTION
## What
Adds the Alpine `libexpat` package to the `apk --no-cache --upgrade` step so libexpat is upgraded to **2.8.1-r0** at image build time.

## Why
Trivy flagged **CVE-2026-45186** (HIGH severity) — libexpat DoS via crafted XML input — in the `eclipse-temurin:21-jre-alpine-3.23` base image. The fix (2.8.1-r0) is available in the Alpine 3.23 repos.

Bumping the pinned base-image SHA is **not** sufficient: the latest `21-jre-alpine-3.23` digest (`sha256:704db3c…`) still ships a vulnerable libexpat, so we upgrade the package explicitly at build time (the same approach this repo already uses for libpng/libcrypto3/libssl3/musl/gnutls).

> Note: the vulnerable, base-image-installed package is `libexpat` — a separate subpackage from the standalone `expat` CLI package. We deliberately upgrade `libexpat` (verified: `apk add --upgrade libexpat` bumps the installed lib from 2.7.x → 2.8.1-r0).

## Impact
libexpat is an OS-level XML parsing library in the base image. Our Java service parses XML via the JDK's built-in JAXP/Xerces (pure Java), not libexpat — there are no JNI/native bindings into libexpat, so the crafted-XML DoS path is not reachable from our code. This is a hygiene fix to clear the scan finding.
