### PR TITLE
UID2-7340: publish operator release as pre-release instead of draft

### DIFF
--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -229,12 +229,17 @@ jobs:
           (cd ./deployment/gcp-oidc-deployment-files-${{ needs.start.outputs.new_version }} && zip -r ../../gcp-oidc-deployment-files-${{ needs.start.outputs.new_version }}.zip . )
           (cd manifests && zip -r ../uid2-operator-release-manifests-${{ needs.start.outputs.new_version }}.zip .)
 
-      - name: Create draft release
+      # Publish as a pre-release (not a draft): durable + fetchable by tag
+      # without claiming GA. The Major-release approval gate stays the
+      # check_major job above, and promoting this to Latest in the UI remains
+      # the deliberate manual GA checkpoint. See UID2-7340.
+      - name: Create pre-release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: v${{ needs.start.outputs.new_version }}
           body: ${{ steps.changelog.outputs.changelog }}
-          draft: true
+          draft: false
+          prerelease: true
           files: |
               ./aws-euid-deployment-files-${{ needs.start.outputs.new_version }}.zip
               ./aws-uid2-deployment-files-${{ needs.start.outputs.new_version }}.zip

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -236,6 +236,12 @@ jobs:
       - name: Create pre-release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
+          # tag_name must be explicit. softprops defaults it to github.ref_name
+          # (the dispatch branch, e.g. main) — not the version tag. The draft
+          # masked this (a draft carries no tag until manually published); a
+          # published release needs the tag now or get-by-tag would still 404.
+          # The v<version> tag already exists (pushed by the start job). UID2-7340.
+          tag_name: v${{ needs.start.outputs.new_version }}
           name: v${{ needs.start.outputs.new_version }}
           body: ${{ steps.changelog.outputs.changelog }}
           draft: false


### PR DESCRIPTION
## Summary

`publish-all-operators.yaml` cuts the GitHub Release carrying the private-operator deployment zips (AWS/Azure/GCP) and enclave-ID manifests as a **draft**. Publishing a draft is a manual click most people skip, so release notes are silently lost and `GET /releases/tags/{tag}` 404s even though the git tag exists.

This PR publishes that release as a **pre-release** (`draft:false, prerelease:true`) instead — durable and fetchable by tag without claiming GA.

## What is unchanged
- **Major-release approval gate** — still the `check_major` job (`publish-major` environment).
- **Manual promote-to-`Latest`** — still the deliberate GA checkpoint, done in the UI. Nothing here auto-marks the release as `Latest`.

This is the companion to IABTechLab/uid2-shared-actions#242, which makes the same draft→pre-release change for services going through the shared publish workflows. The operator's **public** docker image already flows through that shared `java-docker` workflow; this PR covers the **private** operator artifacts cut inline here.

## Validation

The full pipeline can't run off a fork (enclave builds, AMIs, attestation need cloud creds + signing), so the changed `createRelease` step was replicated faithfully — including the `files:` deployment-zip asset uploads — in a throwaway repo (`UnifiedID2/bmz-prerelease-smoke`):

| Check | Result |
|---|---|
| `draft:false` + `prerelease:true` | release published as a **pre-release**, not a draft |
| explicit `tag_name` | attaches to `v<version>`; `GET /releases/tags/v<version>` → **200** (was 404 on drafts) |
| `files:` asset upload | all three deployment zips (`aws-uid2`, `azure-cc`, `gcp-oidc`) attached to the published pre-release |

The added `tag_name` matters: softprops defaults it to `github.ref_name` (the dispatch branch), which the draft masked (a draft carries no tag until manually published). Without it the published release would attach to `main` and get-by-tag would still 404 — the tag already exists from the `start` job's `commit_pr_and_merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
