### PR TITLE
UID2-7335: bump base image to fix libexpat (CVE-2026-45186) in Azure CC + GCP OIDC operators

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
-FROM eclipse-temurin@sha256:704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
+# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
+FROM eclipse-temurin@sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
 
 # For Amazon Corretto Crypto Provider
-RUN apk add --no-cache --upgrade gcompat libexpat
+RUN apk add --no-cache gcompat
 
 WORKDIR /app
 EXPOSE 8080

--- a/scripts/azure-cc/Dockerfile
+++ b/scripts/azure-cc/Dockerfile
@@ -1,5 +1,5 @@
-# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
-FROM eclipse-temurin@sha256:704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
+# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
+FROM eclipse-temurin@sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
 
 # Install necessary packages and set up virtual environment
 RUN apk update && apk add --no-cache jq python3 py3-pip && \

--- a/scripts/gcp-oidc/Dockerfile
+++ b/scripts/gcp-oidc/Dockerfile
@@ -1,5 +1,5 @@
-# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
-FROM eclipse-temurin@sha256:704db3c40204a44f471191446ddd9cda5d60dab40f0e15c6507b815ed897238b
+# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
+FROM eclipse-temurin@sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
 
 LABEL "tee.launch_policy.allow_env_override"="API_TOKEN_SECRET_NAME,DEPLOYMENT_ENVIRONMENT,CORE_BASE_URL,OPTOUT_BASE_URL,DEBUG_MODE,SKIP_VALIDATIONS"
 LABEL "tee.launch_policy.log_redirect"="always"


### PR DESCRIPTION
## What
Bumps the `eclipse-temurin` base image to `sha256:3f08b138…` (the 2026-06-22 rebuild of `21-jre-alpine-3.23`) across the **public**, **Azure CC**, and **GCP OIDC** operator Dockerfiles, and removes the now-redundant explicit `libexpat` upgrade from `./Dockerfile`.

## Why
The previous CVE-2026-45186 fix only patched `./Dockerfile` (Public + AWS EIF). The **Azure CC** (`scripts/azure-cc/Dockerfile`) and **GCP OIDC** (`scripts/gcp-oidc/Dockerfile`) private-operator images build from their own Dockerfiles and were **still shipping the vulnerable libexpat 2.7.5-r0**, so the "Publish All Operators" Azure/GCP build jobs kept failing.

The new base image ships **libexpat 2.8.1-r0**, fixing CVE-2026-45186 across all three Alpine images at the base layer (verified by pulling the digest). The explicit `apk add --upgrade libexpat` is no longer needed and is removed.
