### PR TITLE
UID2-6767: publish a GitHub pre-release for scheduled operator builds

### DIFF
--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -151,7 +151,13 @@ jobs:
   createRelease:
     name: Create Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
+    # Also publish on scheduled builds, not just manual dispatch: the deployed
+    # operator versions come from the daily scheduled run, so gating this on
+    # workflow_dispatch left those versions tagged but with no GitHub Release.
+    # The uid2-deployment pre-deploy release gate (UID2-6767) then hard-blocks
+    # any deploy/rollback of such a version. Scheduled runs are always
+    # release_type 'patch' (never Snapshot), so no Snapshot-release edge case.
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     needs: [start, buildPublic, buildGCP, buildAzure, buildAWS, buildAMI]
     steps:
       - name: Checkout repo

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -263,7 +263,7 @@ jobs:
       name: Notify Slack on Failure
       runs-on: ubuntu-latest
       if: failure() && github.ref == 'refs/heads/main'
-      needs: [start, buildPublic, buildGCP, buildAzure, buildAWS, buildAMI]
+      needs: [start, buildPublic, buildGCP, buildAzure, buildAWS, buildAMI, createRelease]
       steps:
         - name: Send Slack Alert
           env:


### PR DESCRIPTION
## Summary
The `createRelease` job in `publish-all-operators.yaml` only ran on manual `workflow_dispatch`, not on the daily `schedule`. But the operator image versions that actually get deployed (e.g. `5.70.25`) come from the **scheduled** runs — so they push a `v<version>` git tag but publish **no GitHub Release**.

That collides with the new pre-deployment **release-existence gate** in `uid2-deployment` ([UID2-6767] / UnifiedID2/uid2-deployment#4068): it hard-blocks any deploy or rollback of a non-SNAPSHOT version that has no published GitHub Release, with no override. So the next operator deploy/rollback of a scheduled-build version would block.

## Change
Let `createRelease` run on scheduled builds as well:

```diff
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
```

This reuses the existing, already-tested pre-release logic (changelog + `prerelease: true`, per UID2-7340). Every deployable operator version now gets a Release automatically, so the deployment gate passes with no manual intervention.

## Why this is safe
- **No Snapshot edge case:** scheduled runs always resolve `release_type` to `patch` (`start` job), never `Snapshot`.
- **No double-release:** the public child build keeps `force_release: 'no'`, so only this job creates the Release. Manual-dispatch behaviour is unchanged.
- The `v<version>` tag already exists (pushed by the `start` job), which is what `createRelease` attaches to.

## Tradeoff for reviewers
This publishes **~1 pre-release per day** (release-list noise). The alternative — having the deployment gate accept a git *tag* instead of a Release — was rejected because a tag isn't the reviewed change-evidence the SOC2 gate is meant to enforce. Flag if you'd prefer a different cadence (e.g. only release scheduled builds that pass E2E, or a retention/cleanup policy for stale pre-releases).

## Note
No dedicated Jira ticket is linked yet — creating one was pending confirmation. Motivated by / parent: [UID2-6767]. Happy to file + link a follow-up.

[UID2-6767]: https://thetradedesk.atlassian.net/browse/UID2-6767

🤖 Generated with [Claude Code](https://claude.com/claude-code)