### PR TITLE
UID2-6767: publish a GitHub pre-release for scheduled and standalone operator builds

### DIFF
--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -268,7 +268,12 @@ jobs:
   notifyFailure:
       name: Notify Slack on Failure
       runs-on: ubuntu-latest
-      if: failure() && github.ref == 'refs/heads/main'
+      # cancelled() catches the case where a needed job (e.g. buildPublic's
+      # image job) loses the operator-version-bump-* concurrency group to a
+      # concurrent standalone dispatch and gets evicted — that surfaces as
+      # "cancelled", not "failure", and failure() alone would miss it, silently
+      # reintroducing the no-Release gap this workflow exists to close.
+      if: (failure() || cancelled()) && github.ref == 'refs/heads/main'
       needs: [start, buildPublic, buildGCP, buildAzure, buildAWS, buildAMI, createRelease]
       steps:
         - name: Send Slack Alert

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -160,11 +160,9 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     # Also publish on scheduled builds, not just manual dispatch: the deployed
-    # operator versions come from the daily scheduled run, so gating this on
-    # workflow_dispatch left those versions tagged but with no GitHub Release.
-    # The uid2-deployment pre-deploy release gate (UID2-6767) then hard-blocks
-    # any deploy/rollback of such a version. Scheduled runs are always
-    # release_type 'patch' (never Snapshot), so no Snapshot-release edge case.
+    # operator versions may come from the daily scheduled run, so
+    # the uid2-deployment pre-deploy release gate won't hard-block
+    # any deploy/rollback of a version due to not having a release.
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     needs: [start, buildPublic, buildGCP, buildAzure, buildAWS, buildAMI]
     steps:

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -151,7 +151,13 @@ jobs:
   createRelease:
     name: Create Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
+    # Also publish on scheduled builds, not just manual dispatch: the deployed
+    # operator versions come from the daily scheduled run, so gating this on
+    # workflow_dispatch left those versions tagged but with no GitHub Release.
+    # The uid2-deployment pre-deploy release gate (UID2-6767) then hard-blocks
+    # any deploy/rollback of such a version. Scheduled runs are always
+    # release_type 'patch' (never Snapshot), so no Snapshot-release edge case.
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     needs: [start, buildPublic, buildGCP, buildAzure, buildAWS, buildAMI]
     steps:
       - name: Checkout repo

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -263,7 +263,7 @@ jobs:
       name: Notify Slack on Failure
       runs-on: ubuntu-latest
       if: failure() && github.ref == 'refs/heads/main'
-      needs: [start, buildPublic, buildGCP, buildAzure, buildAWS, buildAMI]
+      needs: [start, buildPublic, buildGCP, buildAzure, buildAWS, buildAMI, createRelease]
       steps:
         - name: Send Slack Alert
           env:

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -106,6 +106,7 @@ jobs:
       release_type: ${{ needs.start.outputs.release_type }}
       version_number_input: ${{ needs.start.outputs.new_version }}
       vulnerability_severity: ${{ needs.start.outputs.vulnerability_severity }}
+      force_release: 'no' # The createRelease job below publishes the single combined Release; the component build must not.
     secrets: inherit
 
   buildGCP:

--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -33,6 +33,13 @@ jobs:
     name: Start Operator Build
     needs: check_major
     runs-on: ubuntu-latest
+    # Job-level (not workflow-level) so the lock frees when `start` completes,
+    # before buildPublic runs — sharing this group with publish-public-operator
+    # at the workflow level would otherwise deadlock the reusable call. Serializes
+    # this train's version bump against a standalone public-operator dispatch.
+    concurrency:
+      group: operator-version-bump-${{ github.ref }}
+      cancel-in-progress: false
     environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     outputs:
         new_version: ${{ steps.version.outputs.new_version }}

--- a/.github/workflows/publish-public-operator-docker-image.yaml
+++ b/.github/workflows/publish-public-operator-docker-image.yaml
@@ -23,7 +23,7 @@ on:
         - CRITICAL,HIGH,MEDIUM
         - CRITICAL (DO NOT use if JIRA ticket not raised)
       force_release:
-        description: "Create a GitHub Release for this build. 'branch' (default) releases only Patch/Minor/Major builds on the default or a release branch; 'no' skips; 'yes' forces a release regardless of branch."
+        description: "Create a GitHub Release for this build. 'branch' (default) releases only Patch/Minor/Major builds on the default or a release branch; 'no' skips; 'yes' forces regardless of branch. NOTE: a Patch/Minor/Major dispatch on main commits a version bump + pushes the v<version> tag to main and publishes a public-operator-only pre-release (private-operator images for that version are not built here)."
         type: choice
         default: branch
         options:

--- a/.github/workflows/publish-public-operator-docker-image.yaml
+++ b/.github/workflows/publish-public-operator-docker-image.yaml
@@ -70,6 +70,15 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.release_type == 'Major' && 'publish-major' || '' }}
     steps:
+      # check_branch_and_release_type sets IS_RELEASE=true unconditionally for
+      # force_release='yes', with no release_type check — so without this guard
+      # a Snapshot dispatch could be forced into a GitHub Release/tag, which the
+      # rest of this PR's safety reasoning assumes is impossible.
+      - name: Reject Snapshot + forced release
+        if: ${{ inputs.release_type == 'Snapshot' && inputs.force_release == 'yes' }}
+        run: |
+          echo "::error::force_release=yes cannot be combined with release_type=Snapshot — this would publish a Snapshot GitHub Release/tag."
+          exit 1
       - run: echo "${{ inputs.release_type == 'Major' && 'Major release approved' || 'Skipped - not a Major release' }}"
 
   image:

--- a/.github/workflows/publish-public-operator-docker-image.yaml
+++ b/.github/workflows/publish-public-operator-docker-image.yaml
@@ -55,6 +55,15 @@ on:
         description: The tag used to describe the image in Docker
         value: ${{ jobs.Image.outputs.image_tag }}
 
+# Serialize with publish-all-operators' version bump: its `start` job shares this
+# group. A standalone Patch/Minor/Major dispatch on main and the scheduled
+# full-train both commit a pom bump + push v<version>, so one group per ref keeps
+# them from racing into a push conflict / duplicate-tag failure. cancel-in-progress
+# is false so an in-flight bump/release is queued behind, never killed.
+concurrency:
+  group: operator-version-bump-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   check_major:
     name: Check if major release

--- a/.github/workflows/publish-public-operator-docker-image.yaml
+++ b/.github/workflows/publish-public-operator-docker-image.yaml
@@ -22,6 +22,14 @@ on:
         - CRITICAL,HIGH
         - CRITICAL,HIGH,MEDIUM
         - CRITICAL (DO NOT use if JIRA ticket not raised)
+      force_release:
+        description: "Create a GitHub Release for this build. 'branch' (default) releases only Patch/Minor/Major builds on the default or a release branch; 'no' skips; 'yes' forces a release regardless of branch."
+        type: choice
+        default: branch
+        options:
+        - branch
+        - "no"
+        - "yes"
 
   workflow_call:
     inputs:
@@ -37,6 +45,10 @@ on:
         description: The severity to fail the workflow if such vulnerability is detected. DO NOT override it unless a Jira ticket is raised. Must be one of ['CRITICAL', 'CRITICAL,HIGH' or 'CRITICAL,HIGH,MEDIUM'] (without space in between).
         type: string
         default: 'CRITICAL,HIGH'
+      force_release:
+        description: Whether the shared build should publish a GitHub Release. The parent publish-all-operators passes 'no' because it creates the combined Release itself.
+        type: string
+        default: 'no'
 
     outputs:
       image_tag:
@@ -66,7 +78,7 @@ jobs:
     with:
       release_type: ${{ inputs.release_type }}
       version_number_input: ${{ inputs.version_number_input }}
-      force_release: 'no' # Do not create a release for the component builds, will be created by the parent
+      force_release: ${{ inputs.force_release }} # Standalone dispatch: 'branch' default releases main builds. From publish-all-operators: 'no' (parent creates the combined Release).
       vulnerability_severity: ${{ inputs.vulnerability_severity }}
       java_version: 21
       merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}

--- a/.github/workflows/publish-public-operator-docker-image.yaml
+++ b/.github/workflows/publish-public-operator-docker-image.yaml
@@ -55,15 +55,6 @@ on:
         description: The tag used to describe the image in Docker
         value: ${{ jobs.Image.outputs.image_tag }}
 
-# Serialize with publish-all-operators' version bump: its `start` job shares this
-# group. A standalone Patch/Minor/Major dispatch on main and the scheduled
-# full-train both commit a pom bump + push v<version>, so one group per ref keeps
-# them from racing into a push conflict / duplicate-tag failure. cancel-in-progress
-# is false so an in-flight bump/release is queued behind, never killed.
-concurrency:
-  group: operator-version-bump-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
   check_major:
     name: Check if major release
@@ -85,6 +76,18 @@ jobs:
     name: Image
     uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-publish-java-to-docker-versioned.yaml@v3
     needs: check_major
+    # Job-level (not workflow-level) so the lock covers only this job's version
+    # bump + tag push, not the e2e/artifact-collection jobs that follow — those
+    # don't touch pom.xml/tags and shouldn't extend the hold time. Shares the
+    # group with publish-all-operators' `start` job. cancel-in-progress is false
+    # so an in-flight bump/release is queued rather than killed, though only one
+    # waiter deep: a third concurrent trigger cancels the queued second one
+    # (GitHub Actions concurrency semantics, not specific to this workflow) —
+    # notifyFailure's cancelled() check in publish-all-operators.yaml is the
+    # backstop if that happens.
+    concurrency:
+      group: operator-version-bump-${{ github.ref }}
+      cancel-in-progress: false
     permissions:
       contents: write
       security-events: write


### PR DESCRIPTION
## Problem
`uid2-deployment` #4068 ([UID2-6767]) adds a pre-deployment **GitHub-Release-existence gate**: deploying a non-SNAPSHOT operator image version **hard-blocks** unless a published GitHub Release exists for that version (no override). But operator produces deployable image versions on build paths that publish **no** Release, so those deploys/rollbacks would block. Two such paths exist:

1. **Scheduled full-train** — `publish-all-operators.yaml` runs daily (`cron: 0 0 * * *`) and its `createRelease` job (which publishes a pre-release, per UID2-7340) was gated `if: github.event_name == 'workflow_dispatch'`. So scheduled builds pushed a `v<version>` tag but **no Release**. The frequently-deployed versions (e.g. `5.70.25`) come from here → tags exist up to `v5.70.193` with no matching Releases.
2. **Standalone public build** — `publish-public-operator-docker-image.yaml` (dispatched directly, incl. on `main`) hard-coded `force_release: 'no'`, so it produced a deployable image with **no tag and no Release**.

This PR makes every deployable operator version publish a pre-release automatically, so the gate passes with no manual intervention — while keeping exactly **one** Release per version.

## Changes

**1. Run `createRelease` on scheduled builds** (`publish-all-operators.yaml`)
```diff
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
```
Reuses the existing pre-release logic. Scheduled runs always resolve `release_type` to `patch` (never `Snapshot`), so no Snapshot-release edge case.

**2. Alert on `createRelease` failure** (`publish-all-operators.yaml`)
`createRelease` now runs unattended daily, so it was added to `notifyFailure.needs` — a failure isolated to it (all build jobs green) would otherwise skip the Slack alert.

**3. `force_release` input on the public build** (`publish-public-operator-docker-image.yaml` + `publish-all-operators.yaml`)
Replaces the hard-coded `force_release: 'no'` with an input: default `'branch'` on `workflow_dispatch`, default `'no'` on `workflow_call`. The parent `buildPublic` passes `'no'` explicitly, so only the parent's `createRelease` cuts the single combined Release — **no double-up**. Behaviour:

| Trigger | Result |
|---|---|
| Standalone dispatch on `main`, Patch/Minor/Major | pre-release + tag + version bump |
| Standalone dispatch on a feature branch | no release (branch guard in `check_branch_and_release_type`) |
| Standalone dispatch, Snapshot (the default `release_type`) | no release |
| Called by `publish-all-operators` | no release; parent's `createRelease` owns it |

`release_type: Snapshot` + `force_release: yes` is rejected by a fail-fast guard in `check_major` — `check_branch_and_release_type` sets `is_release=true` unconditionally for `force_release: yes`, with no release-type check, so without the guard this combination would force a Snapshot Release/tag.

**4. Document the standalone side effect** (`publish-public-operator-docker-image.yaml`)
The `force_release` input description now states that a Patch/Minor/Major dispatch on `main` commits a version bump + pushes the `v<version>` tag and publishes a **public-operator-only** pre-release — so it's visible in the Run-workflow UI, not just git history.

**5. Serialize version bumps with a shared concurrency group** (`publish-public-operator-docker-image.yaml` + `publish-all-operators.yaml`)
Change 3 means a standalone Patch/Minor/Major dispatch on `main` now bumps the pom + pushes a tag — which can **race** the scheduled full-train doing the same (push conflict / duplicate-tag failure). Added a shared group `operator-version-bump-${{ github.ref }}` so the two can't bump at once:
- **job-level on the `image` job** of `publish-public-operator-docker-image.yaml` — scoped to just the version-bump/tag-push job, not the `e2e`/artifact-collection jobs that run after it.
- **job-level on the `start` job** of `publish-all-operators.yaml` — for the same reason, and so the lock frees before `buildPublic` (a reusable call sharing the group) runs, avoiding a deadlock.
- `cancel-in-progress: false` queues one in-flight bump/release rather than killing it. GitHub Actions only queues one waiter deep, so a third concurrent trigger would still cancel the queued second one — `notifyFailure` now also fires on `cancelled()` (not just `failure()`) as a backstop for that case.

## Why this is safe (verified in two review passes over the reusable-workflow call graph)
- **No Snapshot releases** — scheduled runs are `patch`; standalone `release_type` defaults to `Snapshot` → `is_release=false`; `Snapshot` + `force_release: yes` is explicitly rejected.
- **No double-release** — `force_release: 'no'` → `is_release=false` → every release step in `shared_create_releases` is a no-op; parent's `createRelease` is the sole releaser on the full train.
- **No deadlock** — job-level concurrency on both `start` and `image` frees before the next stage sharing the group runs.
- **Tag-before-verify ordering** holds — the tag is pushed by `commit_pr_and_merge` before `shared_create_releases`' "verify tag exists" step.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
