### PR TITLE
UID2-7489: route /optout/status through the blocking handler when async batch requests are enabled

### DIFF
--- a/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
+++ b/src/main/java/com/uid2/operator/vertx/UIDOperatorVerticle.java
@@ -301,11 +301,6 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                 rc -> encryptedPayloadHandler.handle(rc, this::handleKeysRequestV2), Role.ID_READER));
         mainRouter.post(V2_TOKEN_LOGOUT.toString()).handler(bodyHandler).handler(auth.handleV1(
                 rc -> encryptedPayloadHandler.handleAsync(rc, this::handleLogoutAsyncV2), Role.OPTOUT));
-        if (this.optOutStatusApiEnabled) {
-            mainRouter.post(V2_OPTOUT_STATUS.toString()).handler(bodyHandler).handler(auth.handleV1(
-                    rc -> encryptedPayloadHandler.handle(rc, this::handleOptoutStatus),
-                    Role.MAPPER, Role.SHARER, Role.ID_READER));
-        }
 
         if (this.clientSideTokenGenerate)
             mainRouter.post(V2_TOKEN_CLIENTGENERATE.toString()).handler(bodyHandler).handler(this::handleClientSideTokenGenerate);
@@ -322,6 +317,11 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                     rc -> encryptedPayloadHandler.handle(rc, this::handleIdentityMapV2), Role.MAPPER), false);
             mainRouter.post(V3_IDENTITY_MAP.toString()).handler(bodyHandler).blockingHandler(auth.handleV1(
                     rc -> encryptedPayloadHandler.handle(rc, this::handleIdentityMapV3), Role.MAPPER), false);
+            if (this.optOutStatusApiEnabled) {
+                mainRouter.post(V2_OPTOUT_STATUS.toString()).handler(bodyHandler).blockingHandler(auth.handleV1(
+                        rc -> encryptedPayloadHandler.handle(rc, this::handleOptoutStatus),
+                        Role.MAPPER, Role.SHARER, Role.ID_READER), false);
+            }
         } else {
             LOGGER.info("Async batch requests disabled");
             mainRouter.post(V2_KEY_SHARING.toString()).handler(bodyHandler).handler(auth.handleV1(
@@ -334,6 +334,11 @@ public class UIDOperatorVerticle extends AbstractVerticle {
                     rc -> encryptedPayloadHandler.handle(rc, this::handleIdentityMapV2), Role.MAPPER));
             mainRouter.post(V3_IDENTITY_MAP.toString()).handler(bodyHandler).handler(auth.handleV1(
                     rc -> encryptedPayloadHandler.handle(rc, this::handleIdentityMapV3), Role.MAPPER));
+            if (this.optOutStatusApiEnabled) {
+                mainRouter.post(V2_OPTOUT_STATUS.toString()).handler(bodyHandler).handler(auth.handleV1(
+                        rc -> encryptedPayloadHandler.handle(rc, this::handleOptoutStatus),
+                        Role.MAPPER, Role.SHARER, Role.ID_READER));
+            }
         }
     }
 

--- a/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
+++ b/src/test/java/com/uid2/operator/UIDOperatorVerticleTest.java
@@ -172,6 +172,10 @@ public class UIDOperatorVerticleTest {
             asyncBatchRequestLogWatcher.start();
             ((Logger) LoggerFactory.getLogger(UIDOperatorVerticle.class)).addAppender(asyncBatchRequestLogWatcher);
         }
+        if (testInfo.getTestMethod().isPresent() &&
+                testInfo.getTestMethod().get().getName().equals("optOutStatusRequestWithAsyncBatchEnabled")) {
+            config.put(Const.Config.EnableAsyncBatchRequestProp, true);
+        }
         when(configStore.getConfig()).thenAnswer(x -> runtimeConfig);
 
         this.uidInstanceIdProvider = new UidInstanceIdProvider("test-instance", "id");
@@ -2304,6 +2308,28 @@ public class UIDOperatorVerticleTest {
                 long expectedTimestamp = Instant.ofEpochSecond(optedOutIds.get(advertisingId)).toEpochMilli();
                 assertEquals(expectedTimestamp, optOutObject.getLong("opted_out_since"));
             }
+            testContext.completeNow();
+        });
+    }
+
+    @Test
+    void optOutStatusRequestWithAsyncBatchEnabled(Vertx vertx, VertxTestContext testContext) {
+        fakeAuth(126, Role.MAPPER);
+        setupKeys();
+        setupSalts(true);
+
+        String rawUid = "qAmIGxqLk_RhOtm4f1nLlqYewqSma8fgvjEXYnQ3Jr0K";
+        long optedOutSince = Instant.now().minus(1, DAYS).getEpochSecond();
+        when(this.optOutStore.getOptOutTimestampByAdId(rawUid)).thenReturn(optedOutSince);
+
+        JsonObject requestJson = new JsonObject();
+        requestJson.put("advertising_ids", new JsonArray().add(rawUid));
+
+        send(vertx, "v2/optout/status", requestJson, 200, respJson -> {
+            assertEquals("success", respJson.getString("status"));
+            JsonArray optOutJsonArray = respJson.getJsonObject("body").getJsonArray("opted_out");
+            assertEquals(1, optOutJsonArray.size());
+            assertEquals(rawUid, optOutJsonArray.getJsonObject(0).getString("advertising_id"));
             testContext.completeNow();
         });
     }


### PR DESCRIPTION
## Summary

`/v2/optout/status` is a **batch endpoint** — it accepts up to `optout_status_max_request_size` (default 5000) advertising IDs per request and looks each up in the opt-out store. However, it was registered with a plain event-loop `handler(...)` **regardless** of the `enable_async_batch_request` flag, unlike the other batch/mapping endpoints:

| Endpoint | `enable_async_batch_request=true` | `=false` |
|---|---|---|
| `key/sharing`, `key/bidstream`, `identity/buckets`, `identity/map` (v2/v3) | `blockingHandler(..., false)` (worker pool) | `handler(...)` (event loop) |
| `optout/status` (before) | `handler(...)` (event loop) — **inconsistent** | `handler(...)` (event loop) |
| `optout/status` (after) | `blockingHandler(..., false)` (worker pool) | `handler(...)` (event loop) |

This PR moves the `optout/status` registration into the existing `isAsyncBatchRequestsEnabled` if/else (still guarded by `optOutStatusApiEnabled`), so it is offloaded to the Vert.x worker pool when async batch requests are enabled — mirroring `identity/map`.

## Why

`optout/status` has the same "potentially heavy per-request work" profile as `identity/map` (up to 5000 lookups/request). When async batch offloading is enabled to keep the event loop responsive, this endpoint should be included; leaving it on the event loop undermines the purpose of the flag.

## Risk / rollout

Low. With `enable_async_batch_request=false` (the current default) the behaviour is **byte-for-byte identical** to before — this is a no-op in current prod config. The worker-pool path only activates under the same flag that already governs the other batch endpoints, and the request/response contract is unchanged; only the executing thread differs. `ordered=false` matches the sibling endpoints (no cross-request ordering requirement).

## Testing

- Added `optOutStatusRequestWithAsyncBatchEnabled` — asserts `/v2/optout/status` still returns a correct success response with `enable_async_batch_request=true` (i.e. via the blocking handler path).
- Ran the opt-out status + async-batch tests under JDK 21: **15 run, 0 failures, 0 errors**.

Jira: [UID2-7489](https://thetradedesk.atlassian.net/browse/UID2-7489)

🤖 Generated with [Claude Code](https://claude.com/claude-code)