### PR TITLE
UID2-7505: Point v2 envelope error responses to encryption/decryption docs

### DIFF
--- a/src/main/java/com/uid2/operator/service/V2RequestUtil.java
+++ b/src/main/java/com/uid2/operator/service/V2RequestUtil.java
@@ -51,6 +51,14 @@ public class V2RequestUtil {
 
     private static final byte VERSION = 1;
 
+    // Appended to request-envelope parse errors to help callers who send an unencrypted body (e.g. a raw
+    // curl request with base64-encoded JSON) understand that the body must be an encrypted request envelope.
+    static final String ENCRYPTION_HINT = " The request body must be an encrypted request envelope, not plain or"
+            + " base64-encoded JSON. If you are calling this endpoint directly (for example with curl), base64-encoding"
+            + " the JSON is not enough. See"
+            + " https://unifiedid.com/docs/getting-started/gs-encryption-decryption#encryption-and-decryption-code-examples"
+            + " for payload encryption and response decryption code examples.";
+
     public static final int V2_REFRESH_PAYLOAD_LENGTH = 388;
     public static final long V2_REQUEST_TIMESTAMP_DRIFT_THRESHOLD_IN_MINUTES = 1;
 
@@ -119,18 +127,18 @@ public class V2RequestUtil {
         }
 
         if (bodyBytes.length < MIN_PAYLOAD_LENGTH) {
-            return new V2Request("Invalid body: Body too short. Check encryption method.");
+            return new V2Request("Invalid body: Body too short. Check encryption method." + ENCRYPTION_HINT);
         }
 
         if (bodyBytes[0] != VERSION) {
-            return new V2Request("Invalid body: Version mismatch.");
+            return new V2Request("Invalid body: Version mismatch." + ENCRYPTION_HINT);
         }
 
         byte[] decryptedBody;
         try {
             decryptedBody = AesGcm.decrypt(bodyBytes, 1, ck.getSecretBytes());
         } catch (Exception ex) {
-            return new V2Request("Invalid body: Check encryption key (ClientSecret)");
+            return new V2Request("Invalid body: Check encryption key (ClientSecret)" + ENCRYPTION_HINT);
         }
 
         // Request envelop format:

--- a/src/test/java/com/uid2/operator/V2RequestUtilTest.java
+++ b/src/test/java/com/uid2/operator/V2RequestUtilTest.java
@@ -120,7 +120,24 @@ public class V2RequestUtilTest {
 
         V2RequestUtil.V2Request res = V2RequestUtil.parseRequestAsString("dGVzdA==", null, clock);
 
-        assertEquals("Invalid body: Body too short. Check encryption method.", res.errorMessage);
+        assertThat(res.errorMessage).startsWith("Invalid body: Body too short. Check encryption method.");
+        assertThat(res.errorMessage).contains("gs-encryption-decryption");
+    }
+
+    @Test
+    public void testParseRequestWithVersionMismatch() {
+        when(clock.now()).thenReturn(MOCK_NOW);
+
+        // Base64 of plain (unencrypted) JSON long enough to pass the length check but whose first byte
+        // is not the expected envelope version byte - this is what a raw curl-with-base64 request produces.
+        String plainJsonBase64 = java.util.Base64.getEncoder().encodeToString(
+                "{\"email_hash\":\"tMmiiTI7IaAcPpQPFQ65uMVCWH8av9jw4cwf/F5HVRQ=\",\"version\":2}"
+                        .getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        V2RequestUtil.V2Request res = V2RequestUtil.parseRequestAsString(plainJsonBase64, null, clock);
+
+        assertThat(res.errorMessage).startsWith("Invalid body: Version mismatch.");
+        assertThat(res.errorMessage).contains("gs-encryption-decryption");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Makes the v2 request-envelope parse errors in `V2RequestUtil` self-explanatory so callers who send an **unencrypted** body (e.g. a raw `curl` request with base64-encoded JSON) understand that the body must be an **encrypted request envelope**.

Private Operator customers repeatedly call `/v2/token/generate` directly with:

```
curl -X POST ".../v2/token/generate" \
  -H "Authorization: Bearer <key>" -H "X-UID2-Client-Secret: <secret>" \
  -d "$(echo -n '{"email_hash":"...","version":2}' | base64 -w 0)"
```

Because the body is base64 of plain JSON (not an encrypted v2 envelope), byte 0 fails the version check and the operator returns the opaque:

```
{"message":"Invalid body: Version mismatch.","status":"client_error"}
```

Nothing in that message tells the caller the real problem is that the payload must be encrypted. In a recent support thread this caused days of back-and-forth — the customer kept re-running curl-with-base64 tests, got "Version mismatch" each time, and mistook it for a server-side bug.

## Change

Appends a hint to the three envelope-parse errors that fire when the body is not a valid encrypted envelope:

- `Invalid body: Body too short. Check encryption method.`
- `Invalid body: Version mismatch.`
- `Invalid body: Check encryption key (ClientSecret)`

The hint tells the caller the body must be an encrypted request envelope (base64-encoding JSON is not enough) and links to https://unifiedid.com/docs/getting-started/gs-encryption-decryption#encryption-and-decryption-code-examples.

The existing **leading phrase** of each message is preserved, so any downstream code that pattern-matches on the current text is unaffected.

## Testing

- Updated `testParseRequestWithTooShortBody` to assert the leading phrase (via `startsWith`) plus the presence of the docs link.
- Added `testParseRequestWithVersionMismatch`, which feeds base64 of plain JSON (the exact curl failure mode) and asserts both the preserved `Invalid body: Version mismatch.` prefix and the docs link.
- `mvn -Dtest=V2RequestUtilTest test` → `Tests run: 7, Failures: 0, Errors: 0`.

## Jira

[UID2-7505](https://thetradedesk.atlassian.net/browse/UID2-7505)

🤖 Generated with [Claude Code](https://claude.com/claude-code)