### PR TITLE
UID2-7557: suppress jackson-core GHSA-r7wm-3cxj-wff9 (async parser, not reachable)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -31,12 +31,6 @@ CVE-2026-22184 exp:2026-09-09
 # Availability only (C:N/I:N/A:H). Tracking via UID2-7035; revisit on vert.x 5 migration.
 CVE-2026-42577 exp:2026-09-11
 
-# CVE-2026-45447 — libcrypto3 PKCS#7/S/MIME memory corruption in Alpine base image.
-# uid2-operator is a pure Java service; the JVM uses JSSE for TLS, not the native
-# libcrypto3 C library. No JNI or OpenSSL calls in source. Attack vector (malformed
-# PKCS#7/S/MIME parsing) is not reachable from this service. See: UID2-7279
-CVE-2026-45447 exp:2026-07-11
-
 # jackson-databind data-binding vulnerability - no upstream fix released yet (fix targets: 2.18.8, 2.21.4, 3.1.4)
 # jackson-databind is pulled in transitively via uid2-shared; the version fix is tracked in
 # uid2-shared (https://github.com/IABTechLab/uid2-shared/pull/631) and will flow here on the

--- a/.trivyignore
+++ b/.trivyignore
@@ -62,3 +62,9 @@ CVE-2026-2100 exp:2026-09-01
 CVE-2026-56131 exp:2026-08-09
 CVE-2026-56407 exp:2026-08-09
 CVE-2026-56408 exp:2026-08-09
+
+# jackson-core async parser maxNumberLength bypass (GHSA-r7wm-3cxj-wff9) - incomplete fix for
+# GHSA-72hv-8253-57qq. Not exploitable: services only use the synchronous ObjectMapper API, not
+# jackson-core's non-blocking/async parser. A jackson bump is also in flight via uid2-shared
+# (PR #631) and will flow on the next release. See: UID2-7557 (predecessor UID2-6670)
+GHSA-r7wm-3cxj-wff9 exp:2026-08-23


### PR DESCRIPTION
## Vulnerability suppression — jackson-core GHSA-r7wm-3cxj-wff9 (HIGH)

Async-parser `maxNumberLength` bypass (incomplete fix for GHSA-72hv-8253-57qq). **Not reachable**: this service parses JSON only via the synchronous `ObjectMapper` API, never jackson-core’s non-blocking/async parser — the same rationale under which the predecessor advisory was suppressed (UID2-6670). A jackson bump is also in flight via uid2-shared PR #631 and will flow on the next release, at which point this can be removed.

Suppressed in `.trivyignore` with expiry **2026-08-23**. Ticket: UID2-7557.