### PR TITLE
[Security] UID2-7569/7570/7571-7574: Upgrade jackson to 2.21.4 and Netty to 4.1.136.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,8 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <java.version>21</java.version>
-        <netty.version>4.1.135.Final</netty.version>
+        <netty.version>4.1.136.Final</netty.version>
+        <jackson.version>2.21.4</jackson.version>
     </properties>
 
 
@@ -48,6 +49,14 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Force jackson to a fixed version to resolve CVE-2026-54512, CVE-2026-54513 (UID2-7569, UID2-7570). -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>


### PR DESCRIPTION
## Summary
Resolves HIGH-severity dependency vulnerabilities flagged by the scheduled Trivy vulnerability scan.

| Dependency | CVEs | Fix |
|---|---|---|
| `jackson-databind` | CVE-2026-54512 (RCE), CVE-2026-54513 (bypass) | jackson-bom `2.21.4` in `dependencyManagement` |
| `io.netty` | CVE-2026-55831, CVE-2026-55833, CVE-2026-56745, CVE-2026-59901 | `netty.version` `4.1.135.Final` → `4.1.136.Final` |

Reachable production dependencies (JSON handling + vert.x transport) → real upgrade, not suppression. The `netty.version` property applies to all operator images (default / Azure-CC / GCP-OIDC).

## Tickets
UID2-7569, UID2-7570 (jackson); UID2-7571–7574 (Netty)

## Testing
Build + unit tests run in CI (no local Maven available).