### PR TITLE
UID2-7582: remove expired .trivyignore suppressions (CVE-2026-54512, CVE-2026-54513)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -31,14 +31,6 @@ CVE-2026-22184 exp:2026-09-09
 # Availability only (C:N/I:N/A:H). Tracking via UID2-7035; revisit on vert.x 5 migration.
 CVE-2026-42577 exp:2026-09-11
 
-# jackson-databind data-binding vulnerability - no upstream fix released yet (fix targets: 2.18.8, 2.21.4, 3.1.4)
-# jackson-databind is pulled in transitively via uid2-shared; the version fix is tracked in
-# uid2-shared (https://github.com/IABTechLab/uid2-shared/pull/631) and will flow here on the
-# next uid2-shared release. Suppressing in the interim.
-# See: UID2-7364
-CVE-2026-54512 exp:2026-07-25
-CVE-2026-54513 exp:2026-07-25
-
 # CVE-2026-2100 — p11-kit NULL dereference via C_DeriveKey in the Alpine base image.
 # uid2-operator is a pure Java service; the JVM uses JSSE for TLS and the bundled Java cacerts keystore for trust — it does
 # not load the native p11-kit PKCS#11 module loader and never calls C_DeriveKey, so the


### PR DESCRIPTION
## Summary

Removes two `.trivyignore` suppressions that expired on **2026-07-25** (3 days ago).

| CVE | Package | Expiry | Original ticket |
|---|---|---|---|
| CVE-2026-54512 | jackson-databind | 2026-07-25 | UID2-7364 |
| CVE-2026-54513 | jackson-databind | 2026-07-25 | UID2-7364 |

## Why this is safe

Trivy stops honouring a suppression once its `exp:` date passes, so these lines have had **no effect since 2026-07-25**. The scheduled vulnerability scan on 2026-07-28 (`00:41:51Z`) passed with both entries already inert, which confirms neither CVE is being reported any more.

The suppressions were always intended as a stopgap — the comment noted the real fix was tracked in [uid2-shared#631](https://github.com/IABTechLab/uid2-shared/pull/631) and would 'flow here on the next uid2-shared release'. That has now happened, so the stopgap can go.

Found by the automated `.trivyignore` expiry audit. Jira: [UID2-7582](https://thetradedesk.atlassian.net/browse/UID2-7582)

🤖 Generated with [Claude Code](https://claude.com/claude-code)