### PR TITLE
UID2-7656: suppress CVE-2026-56408 in .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -47,7 +47,13 @@ CVE-2026-2100 exp:2026-09-01
 # See: UID2-7456
 CVE-2026-56131 exp:2026-08-09
 CVE-2026-56407 exp:2026-08-09
-CVE-2026-56408 exp:2026-08-09
+# CVE-2026-56408 — libexpat (Alpine base image, transitive via eclipse-temurin:21-jre-
+# alpine-3.23) (HIGH).
+# Not exploitable here: Same alpine base (adds only gcompat for Corretto crypto). No native
+# libexpat path; pure-Java XML via JAXP. Nitro builder is a separate ubuntu:22.04 build stage,
+# not the scanned runtime image.
+# See: UID2-7656
+CVE-2026-56408 exp:2026-11-11
 
 # jackson-core async parser maxNumberLength bypass (GHSA-r7wm-3cxj-wff9) - incomplete fix for
 # GHSA-72hv-8253-57qq. Not exploitable: services only use the synchronous ObjectMapper API, not


### PR DESCRIPTION
Suppresses **CVE-2026-56408** (HIGH, `libexpat (Alpine base image, transitive via eclipse-temurin:21-jre-alpine-3.23)`) — present in the image but not reachable from this service. Expiry **2026-11-11** (3 months). No code fix.

**Why:** Integer overflow (CWE-190) in native libexpat's copyString(), reachable only by parsing XML through the libexpat C library. libexpat is present solely as a transitive OS dependency of the eclipse-temurin:21-jre-alpine-3.23 base image (font/fontconfig chain); no repo installs or links it. All five services are pure-Java Vert.x apps that parse XML via the JVM's JAXP/Xerces stack, not native libexpat, and contain no JNI bindings or loadLibrary calls to it. The advisory's local XML-parsing vector cannot be exercised through our build/run configuration, so the vulnerable path is unreachable despite the library being present.

**Evidence:** Dockerfile FROM eclipse-temurin:21-jre-alpine-3.23; libexpat not apk-added, only libpng/libcrypto3/libssl3/gnutls. Pure-Java Vert.x jar; no expat/JNI/loadLibrary refs in any *.java. XML (logback.xml/conf) parsed by JVM JAXP, not native libexpat. Same eclipse-temurin alpine base; libexpat transitive only. No expat/XML_Parse/JNI references in source; JVM handles all XML parsing. Same alpine base (adds only gcompat for Corretto crypto). No native libexpat path; pure-Java XML via JAXP. Nitro builder is a separate ubuntu:22.04 build stage, not the scanned runtime image. Same alpine base; libexpat not explicitly installed. No expat/JNI refs; JVM parses config/logback XML, not libexpat. Same alpine base; no apk libexpat, no native XML path in source. Nitro builder uses ubuntu:22.04 (build-only, not scanned runtime).

Reachability alone determines suppress-vs-fix — a fixed version existing upstream does not make an unreachable path exploitable. Change the expiry in review if you want a different window.

<details>
<summary>Full triage report</summary>

### CVE-2026-56408 — libexpat integer overflow in copyString

#### What the CVE is
libexpat before 2.8.2 contains an integer overflow (CWE-190) in the internal `copyString()` routine. It is reached when the native libexpat C library parses XML input; the OSV/NVD vector is `CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L` (local, high attack complexity). Fixed in libexpat 2.8.2 (Alpine `2.8.2-r0`).

#### What was scanned
The findings come from the container images built by each repo's `Dockerfile`, all of which are `FROM eclipse-temurin@sha256:...` = `eclipse-temurin:21-jre-alpine-3.23`. libexpat `2.8.1-r0` ships in that base image as a **transitive OS dependency** (font-rendering chain: fontconfig → freetype/expat). No repo declares or installs it.

#### How it affects our services — code search
- **No explicit install**: none of the five Dockerfiles `apk add` libexpat. They add only `libpng libcrypto3 libssl3 musl musl-utils gnutls` (admin/core/optout), `gcompat` (operator), or nothing extra (validator).
- **No native path**: a repo-wide search for `expat`, `libexpat`, `XML_Parse`, `JNI`, `System.loadLibrary`, and `native` across `*.java/*.c/*.cpp/*.h/*.xml` returned zero matches.
- **Pure-Java XML**: all five are Vert.x/Java services on the JVM. The only XML they handle (`logback.xml`, `conf/*.xml`) is parsed by the JVM's JAXP/Xerces implementation — pure Java — never by native libexpat.
- **Nitro builders** (operator, validator) are `FROM ubuntu:22.04` and are build-only stages; they are not the alpine runtime artifacts the scanner inspected.

Because these services never invoke libexpat through any JNI/native binding, the advisory's XML-parsing overflow path is not reachable in the way we build and run the artifacts.

#### Decision
**not_affected** for all five repos (uid2-admin, uid2-core, uid2-operator, uid2-optout, uid2-validator). The package is present in the base image (the scan is correct) but unreachable — consistent with the standing rule that Alpine base-image OS libraries are presumed unreachable for pure-Java services absent a demonstrated native path, which does not exist here.

#### Recommended action
Suppress this finding in each repo's root `.trivyignore`. A fixed package (`2.8.2-r0`) exists and will arrive naturally when the base image is bumped, but the fix does not change the not_affected verdict; suppression is appropriate because the path is not exploitable in our services. Confidence: high.

</details>

---
_Opened by uid2-vul-scan-agent (general_use_claude-opus-4-8), verdict confidence high. Please sanity-check the reachability argument before approving._
