### PR TITLE
UID2-7760, UID2-7761: bump eclipse-temurin digest and upgrade openssl to fix Alpine CVEs

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -44,9 +44,12 @@ CVE-2026-2100 exp:2026-09-01
 # JAXP/Xerces implementation, not the native libexpat C library, and there are no JNI bindings or
 # native deps that call into libexpat, so the crafted-XML attack path is not reachable. Fixed in
 # Alpine v3.23 libexpat >= 2.8.2-r0; the pinned eclipse-temurin base image has not yet been rebuilt with it.
+# Renewed rather than removed: Alpine's package index now shows libexpat 2.8.3-r0, above the fix
+# threshold, but that's not yet confirmed inside our pinned image digest. See UID2-7763 for the
+# base-image-bump investigation.
 # See: UID2-7456
-CVE-2026-56131 exp:2026-08-09
-CVE-2026-56407 exp:2026-08-09
+CVE-2026-56131 exp:2026-09-27
+CVE-2026-56407 exp:2026-09-27
 # CVE-2026-56408 — libexpat (Alpine base image, transitive via eclipse-temurin:21-jre-
 # alpine-3.23) (HIGH).
 # Not exploitable here: Same alpine base (adds only gcompat for Corretto crypto). No native
@@ -57,9 +60,9 @@ CVE-2026-56408 exp:2026-11-11
 
 # jackson-core async parser maxNumberLength bypass (GHSA-r7wm-3cxj-wff9) - incomplete fix for
 # GHSA-72hv-8253-57qq. Not exploitable: services only use the synchronous ObjectMapper API, not
-# jackson-core's non-blocking/async parser. A jackson bump is also in flight via uid2-shared
-# (PR #631) and will flow on the next release. See: UID2-7557 (predecessor UID2-6670)
-GHSA-r7wm-3cxj-wff9 exp:2026-08-23
+# jackson-core's non-blocking/async parser. Note: uid2-shared PR #631 (previously cited here as
+# "in flight") was reverted in #633 — not a fix for this GHSA. See: UID2-7557 (predecessor UID2-6670)
+GHSA-r7wm-3cxj-wff9 exp:2026-09-27
 
 # CVE-2026-40984 — io.micrometer:micrometer-core (transitive via micrometer-registry-
 # prometheus/-jmx); micrometer-jetty11/12 not present (HIGH).

--- a/.trivyignore
+++ b/.trivyignore
@@ -2,25 +2,9 @@
 # See https://aquasecurity.github.io/trivy/v0.35/docs/vulnerability/examples/filter/ 
 # for more details
 
-# libpng OOB read in png_image_read_composite - uid2-operator is a pure Java service
-# that never calls into libpng's simplified PNG processing API; the JVM does not use
-# libpng for image handling. Fix is available in Alpine 3.23 >= 1.6.53-r0 but the
-# pinned eclipse-temurin image has not yet been rebuilt with it (tracked alongside
-# sibling CVE-2026-25646 which shares the same base-image lag). See: UID2-6385
-CVE-2025-66293 exp:2026-09-15
-
 # jackson-core async parser DoS - not exploitable, services only use synchronous ObjectMapper API
 # See: UID2-6670
 GHSA-72hv-8253-57qq exp:2026-09-01
-
-# libpng heap buffer overflow in Alpine base image - fixed version not yet available in Alpine 3.23
-# See: UID2-6677
-CVE-2026-25646 exp:2026-09-02
-
-# zlib contrib/untgz demo utility buffer overflow - not exploitable, Alpine does not ship the untgz binary
-# and the core libz library used by the JRE is unaffected. The zlib maintainer disputes this CVE.
-# See: UID2-6704
-CVE-2026-22184 exp:2026-09-09
 
 # CVE-2026-42577 — netty-transport-native-epoll DoS via RST on half-closed TCP connection.
 # Advisory: https://github.com/netty/netty/security/advisories/GHSA-rwm7-x88c-3g2p
@@ -30,33 +14,6 @@ CVE-2026-22184 exp:2026-09-09
 # LB-level connection limits and idle timeouts further cap the blast radius. CVSS impact is
 # Availability only (C:N/I:N/A:H). Tracking via UID2-7035; revisit on vert.x 5 migration.
 CVE-2026-42577 exp:2026-09-11
-
-# CVE-2026-2100 — p11-kit NULL dereference via C_DeriveKey in the Alpine base image.
-# uid2-operator is a pure Java service; the JVM uses JSSE for TLS and the bundled Java cacerts keystore for trust — it does
-# not load the native p11-kit PKCS#11 module loader and never calls C_DeriveKey, so the
-# vulnerable code path is not reachable. Fixed in Alpine v3.23 >= 0.26.2-r0 but the pinned
-# eclipse-temurin base image has not yet been rebuilt with it.
-# See: UID2-7376
-CVE-2026-2100 exp:2026-09-01
-
-# CVE-2026-56131 / CVE-2026-56407 / CVE-2026-56408 — libexpat stack exhaustion / integer overflows
-# in the Alpine base image. uid2-operator is a pure Java service; the JVM parses XML via the built-in
-# JAXP/Xerces implementation, not the native libexpat C library, and there are no JNI bindings or
-# native deps that call into libexpat, so the crafted-XML attack path is not reachable. Fixed in
-# Alpine v3.23 libexpat >= 2.8.2-r0; the pinned eclipse-temurin base image has not yet been rebuilt with it.
-# Renewed rather than removed: Alpine's package index now shows libexpat 2.8.3-r0, above the fix
-# threshold, but that's not yet confirmed inside our pinned image digest. See UID2-7763 for the
-# base-image-bump investigation.
-# See: UID2-7456
-CVE-2026-56131 exp:2026-09-27
-CVE-2026-56407 exp:2026-09-27
-# CVE-2026-56408 — libexpat (Alpine base image, transitive via eclipse-temurin:21-jre-
-# alpine-3.23) (HIGH).
-# Not exploitable here: Same alpine base (adds only gcompat for Corretto crypto). No native
-# libexpat path; pure-Java XML via JAXP. Nitro builder is a separate ubuntu:22.04 build stage,
-# not the scanned runtime image.
-# See: UID2-7656
-CVE-2026-56408 exp:2026-11-11
 
 # jackson-core async parser maxNumberLength bypass (GHSA-r7wm-3cxj-wff9) - incomplete fix for
 # GHSA-72hv-8253-57qq. Not exploitable: services only use the synchronous ObjectMapper API, not
@@ -72,20 +29,3 @@ GHSA-r7wm-3cxj-wff9 exp:2026-09-27
 # See: UID2-7662
 CVE-2026-40984 exp:2026-11-11
 
-# CVE-2026-11822 / CVE-2026-11824 — sqlite-libs (Alpine base image, transitive via
-# eclipse-temurin:21-jre-alpine-3.23) (HIGH). Not exploitable: uid2-operator is a pure Java
-# service with no SQLite/JDBC driver dependency and no JNI bindings; the FTS5 attack path
-# requires an application to invoke SQLite's full-text search engine, which this service
-# never does. Same pattern already confirmed for uid2-admin in UID2-7748.
-# See: UID2-7760
-CVE-2026-11822 exp:2026-09-27
-CVE-2026-11824 exp:2026-09-27
-
-# CVE-2026-14456 — libcrypto3/libssl3 (openssl, Alpine base image, transitive via
-# eclipse-temurin:21-jre-alpine-3.23) (HIGH): DoS via unbounded memory growth in an OpenSSL
-# QUIC server. Not exploitable: uid2-operator terminates TLS via JSSE over plain TCP and
-# never runs an OpenSSL QUIC server. The bundled Amazon Corretto Crypto Provider (ACCP) only
-# exposes JCA Cipher/Signature/MessageDigest/KeyAgreement via OpenSSL's EVP API — it never
-# touches libssl's QUIC server implementation, so ACCP does not make this path reachable.
-# See: UID2-7761
-CVE-2026-14456 exp:2026-09-27

--- a/.trivyignore
+++ b/.trivyignore
@@ -68,3 +68,21 @@ GHSA-r7wm-3cxj-wff9 exp:2026-08-23
 # by Vert.x instrumentation, not Micrometer's vulnerable HTTP server binder
 # See: UID2-7662
 CVE-2026-40984 exp:2026-11-11
+
+# CVE-2026-11822 / CVE-2026-11824 — sqlite-libs (Alpine base image, transitive via
+# eclipse-temurin:21-jre-alpine-3.23) (HIGH). Not exploitable: uid2-operator is a pure Java
+# service with no SQLite/JDBC driver dependency and no JNI bindings; the FTS5 attack path
+# requires an application to invoke SQLite's full-text search engine, which this service
+# never does. Same pattern already confirmed for uid2-admin in UID2-7748.
+# See: UID2-7760
+CVE-2026-11822 exp:2026-09-27
+CVE-2026-11824 exp:2026-09-27
+
+# CVE-2026-14456 — libcrypto3/libssl3 (openssl, Alpine base image, transitive via
+# eclipse-temurin:21-jre-alpine-3.23) (HIGH): DoS via unbounded memory growth in an OpenSSL
+# QUIC server. Not exploitable: uid2-operator terminates TLS via JSSE over plain TCP and
+# never runs an OpenSSL QUIC server. The bundled Amazon Corretto Crypto Provider (ACCP) only
+# exposes JCA Cipher/Signature/MessageDigest/KeyAgreement via OpenSSL's EVP API — it never
+# touches libssl's QUIC server implementation, so ACCP does not make this path reachable.
+# See: UID2-7761
+CVE-2026-14456 exp:2026-09-27

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
-FROM eclipse-temurin@sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
+# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-319339a7fc9c7b59478cbed0340b6ba4944b45384a6eba3b0086856f4af08d8d
+FROM eclipse-temurin@sha256:319339a7fc9c7b59478cbed0340b6ba4944b45384a6eba3b0086856f4af08d8d
 
 # For Amazon Corretto Crypto Provider
-RUN apk add --no-cache gcompat
+RUN apk add --no-cache gcompat && apk add --no-cache --upgrade libcrypto3 libssl3
 
 WORKDIR /app
 EXPOSE 8080

--- a/scripts/azure-cc/Dockerfile
+++ b/scripts/azure-cc/Dockerfile
@@ -1,5 +1,5 @@
-# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
-FROM eclipse-temurin@sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
+# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-319339a7fc9c7b59478cbed0340b6ba4944b45384a6eba3b0086856f4af08d8d
+FROM eclipse-temurin@sha256:319339a7fc9c7b59478cbed0340b6ba4944b45384a6eba3b0086856f4af08d8d
 
 # Install necessary packages and set up virtual environment
 RUN apk update && apk add --no-cache jq python3 py3-pip && \

--- a/scripts/gcp-oidc/Dockerfile
+++ b/scripts/gcp-oidc/Dockerfile
@@ -1,5 +1,5 @@
-# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
-FROM eclipse-temurin@sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
+# sha from https://hub.docker.com/layers/library/eclipse-temurin/21-jre-alpine-3.23/images/sha256-319339a7fc9c7b59478cbed0340b6ba4944b45384a6eba3b0086856f4af08d8d
+FROM eclipse-temurin@sha256:319339a7fc9c7b59478cbed0340b6ba4944b45384a6eba3b0086856f4af08d8d
 
 LABEL "tee.launch_policy.allow_env_override"="API_TOKEN_SECRET_NAME,DEPLOYMENT_ENVIRONMENT,CORE_BASE_URL,OPTOUT_BASE_URL,DEBUG_MODE,SKIP_VALIDATIONS"
 LABEL "tee.launch_policy.log_redirect"="always"


### PR DESCRIPTION
## Summary
Several HIGH-severity CVEs flagged in the Alpine base image (eclipse-temurin:21-jre-alpine-3.23) were originally suppressed in `.trivyignore` as non-exploitable. A newer build of the same pinned tag turns out to already ship fixed versions of most of the affected packages — confirmed by pulling and inspecting the image directly (`apk list -I`), not just trusting the Alpine package index:

- CVE-2026-11822 / CVE-2026-11824 (sqlite-libs), CVE-2026-2100 (p11-kit), CVE-2026-56131/56407/56408 (libexpat), CVE-2025-66293 / CVE-2026-25646 (libpng), CVE-2026-22184 (zlib) — fixed by the digest bump.
- CVE-2026-14456 (libcrypto3/libssl3/openssl) — **not** fixed by the digest bump (still ships 3.5.7-r0); added an explicit `apk add --no-cache --upgrade libcrypto3 libssl3` to pull 3.5.8-r0 from the live Alpine v3.23 mirror at build time instead.

Also bumps the same pinned digest in `scripts/gcp-oidc/Dockerfile` and `scripts/azure-cc/Dockerfile`, which pin the identical base image.

Removes the now-unnecessary `.trivyignore` entries for all of the above.

Jira: https://thetradedesk.atlassian.net/browse/UID2-7760, https://thetradedesk.atlassian.net/browse/UID2-7761

## Test plan
- [x] `mvn package` + `docker build` with the new digest and openssl upgrade, then `trivy image --severity HIGH,CRITICAL` against the built image — 0 findings
- [x] Verified `apk add --upgrade libcrypto3 libssl3` resolves to 3.5.8-r0 (fixed version) against the new base image