### PR TITLE
UID2-7805: Fix workflow_dispatch CRITICAL vulnerability_severity option

### DIFF
--- a/.github/workflows/publish-all-operators.yaml
+++ b/.github/workflows/publish-all-operators.yaml
@@ -12,12 +12,12 @@ on:
         - Major
         - Snapshot
       vulnerability_severity:
-        description: The severity to fail the workflow if such vulnerability is detected. DO NOT override it unless a Jira ticket is raised.
+        description: The severity to fail the workflow if such vulnerability is detected. DO NOT override it unless a Jira ticket is raised. DO NOT use 'CRITICAL' unless a Jira ticket is raised.
         type: choice
         options:
         - CRITICAL,HIGH
         - CRITICAL,HIGH,MEDIUM
-        - CRITICAL (DO NOT use if JIRA ticket not raised)
+        - CRITICAL
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/publish-azure-cc-enclave-docker.yaml
+++ b/.github/workflows/publish-azure-cc-enclave-docker.yaml
@@ -16,12 +16,12 @@ on:
         type: string
         default: ''
       vulnerability_severity:
-        description: The severity to fail the workflow if such vulnerability is detected. DO NOT override it unless a Jira ticket is raised.
+        description: The severity to fail the workflow if such vulnerability is detected. DO NOT override it unless a Jira ticket is raised. DO NOT use 'CRITICAL' unless a Jira ticket is raised.
         type: choice
         options:
         - CRITICAL,HIGH
         - CRITICAL,HIGH,MEDIUM
-        - CRITICAL (DO NOT use if JIRA ticket not raised)
+        - CRITICAL
 
   workflow_call:
     inputs:

--- a/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
+++ b/.github/workflows/publish-gcp-oidc-enclave-docker.yaml
@@ -16,12 +16,12 @@ on:
         type: string
         default: ''
       vulnerability_severity:
-        description: The severity to fail the workflow if such vulnerability is detected. DO NOT override it unless a Jira ticket is raised.
+        description: The severity to fail the workflow if such vulnerability is detected. DO NOT override it unless a Jira ticket is raised. DO NOT use 'CRITICAL' unless a Jira ticket is raised.
         type: choice
         options:
         - CRITICAL,HIGH
         - CRITICAL,HIGH,MEDIUM
-        - CRITICAL (DO NOT use if JIRA ticket not raised)
+        - CRITICAL
   workflow_call:
     inputs:
       release_type:
@@ -163,7 +163,7 @@ jobs:
           image_ref: ${{ steps.meta.outputs.tags }}
           scan_type: 'image'
           skip_files: '/venv/lib/python3.12/site-packages/google/auth/crypt/__pycache__/_python_rsa.cpython-312.pyc' # Skip scanning this file as per UID2-4968
-          failure_severity: ${{ (inputs.vulnerability_severity == 'CRITICAL (DO NOT use if JIRA ticket not raised)' && 'CRITICAL') || inputs.vulnerability_severity }}
+          failure_severity: ${{ inputs.vulnerability_severity }}
 
       # Re-authenticate immediately before registry publish. Build + Trivy can exceed
       # a short-lived GAR token obtained earlier in the job.

--- a/.github/workflows/publish-public-operator-docker-image.yaml
+++ b/.github/workflows/publish-public-operator-docker-image.yaml
@@ -16,12 +16,12 @@ on:
         type: string
         default: ''
       vulnerability_severity:
-        description: The severity to fail the workflow if such vulnerability is detected. DO NOT override it unless a Jira ticket is raised.
+        description: The severity to fail the workflow if such vulnerability is detected. DO NOT override it unless a Jira ticket is raised. DO NOT use 'CRITICAL' unless a Jira ticket is raised.
         type: choice
         options:
         - CRITICAL,HIGH
         - CRITICAL,HIGH,MEDIUM
-        - CRITICAL (DO NOT use if JIRA ticket not raised)
+        - CRITICAL
       force_release:
         description: "Create a GitHub Release for this build. 'branch' (default) releases only Patch/Minor/Major builds on the default or a release branch; 'no' skips; 'yes' forces regardless of branch. NOTE: a Patch/Minor/Major dispatch on main commits a version bump + pushes the v<version> tag to main and publishes a public-operator-only pre-release (private-operator images for that version are not built here)."
         type: choice

--- a/.github/workflows/validate-image.yaml
+++ b/.github/workflows/validate-image.yaml
@@ -3,12 +3,12 @@ on:
   workflow_dispatch:
     inputs:
       failure_severity:
-        description: The severity to fail the workflow if such vulnerability is detected. DO NOT override it unless a Jira ticket is raised.
+        description: The severity to fail the workflow if such vulnerability is detected. DO NOT override it unless a Jira ticket is raised. DO NOT use 'CRITICAL' unless a Jira ticket is raised.
         type: choice
         options:
         - CRITICAL,HIGH
         - CRITICAL,HIGH,MEDIUM
-        - CRITICAL (DO NOT use if JIRA ticket not raised)
+        - CRITICAL
       fail_on_error:
         description: If true, will fail the build if vulnerabilities are found
         required: true


### PR DESCRIPTION
## Summary
- The `vulnerability_severity` (`failure_severity` in `validate-image.yaml`) workflow_dispatch input had a choice literally named `CRITICAL (DO NOT use if JIRA ticket not raised)`, which got passed verbatim into the Trivy/vulnerability-scan severity value — not a valid severity string, so the scan step failed whenever that option was picked (e.g. [this run](https://github.com/IABTechLab/uid2-operator/actions/runs/33712469350)).
- Simplified the option to plain `CRITICAL` and moved the warning into the input's `description` instead, matching the pattern already used in `vulnerability-scan-failure-notify.yaml`.
- Removed the now-unneeded string-matching workaround in `publish-gcp-oidc-enclave-docker.yaml` that had special-cased the old literal string.

Affected files: `publish-all-operators.yaml`, `publish-public-operator-docker-image.yaml`, `publish-azure-cc-enclave-docker.yaml`, `publish-gcp-oidc-enclave-docker.yaml`, `validate-image.yaml`.

## Test plan
- [x] All 5 edited workflow files parse as valid YAML
- [ ] Trigger `Publish All Operators` (or one of the individual publish workflows) via workflow_dispatch selecting `CRITICAL` and confirm the Vulnerability Scan step runs with a valid severity value instead of failing