### PR TITLE
UID2-7804: Revert env_rules workaround (#2720)

### DIFF
--- a/scripts/azure-cc/deployment/generate-deployment-artifacts.sh
+++ b/scripts/azure-cc/deployment/generate-deployment-artifacts.sh
@@ -86,29 +86,7 @@ fi
 POLICY_DIGEST_FILE=azure-cc-operator-digest-$VERSION_NUMBER.txt
 az confcom acipolicygen --approve-wildcards --omit-id --template-file ${OUTPUT_DIR}/operator.json --print-policy > ${INPUT_DIR}/policy.base64
 base64 -di < ${INPUT_DIR}/policy.base64 > ${INPUT_DIR}/generated.rego
-# Azure ACI injects these managed-identity vars into confidential containers, but confcom's built-in
-# ACI-injected allowlist does not yet cover them. Without matching rules the container fails to start,
-# since env-var dropping is off below. skr needs IDENTITY_ENDPOINT/IMDS_ENDPOINT to fetch the
-# managed-identity token for key release, so they must be allowed rather than dropped. See UID2-7797.
-sed -i "s#{\"pattern\":\"IDENTITY_SERVER_THUMBPRINT=.+\",\"required\":false,\"strategy\":\"re2\"},#{\"pattern\":\"IDENTITY_SERVER_THUMBPRINT=.+\",\"required\":false,\"strategy\":\"re2\"},{\"pattern\":\"APP_IDENTITY_ENDPOINT=.+\",\"required\":false,\"strategy\":\"re2\"},{\"pattern\":\"IDENTITY_ENDPOINT=.+\",\"required\":false,\"strategy\":\"re2\"},{\"pattern\":\"IMDS_ENDPOINT=.+\",\"required\":false,\"strategy\":\"re2\"},#g" ${INPUT_DIR}/generated.rego
 sed -i "s#allow_environment_variable_dropping := true#allow_environment_variable_dropping := false#g" ${INPUT_DIR}/generated.rego
-
-# Fail loudly if the edits above did not apply. Both seds are anchored on the exact JSON shape
-# emitted by az confcom, which is not pinned here - if a future version reorders or renames these
-# rules the seds silently no-op and we would publish a policy that cannot attest.
-for ACI_ENV_VAR in APP_IDENTITY_ENDPOINT IDENTITY_ENDPOINT IMDS_ENDPOINT; do
-  RULE_COUNT=$(grep -o "\"${ACI_ENV_VAR}=\.+\"" ${INPUT_DIR}/generated.rego | wc -l)
-  if [[ ${RULE_COUNT} -ne 2 ]]; then
-    echo "Expected 2 env_rules for ${ACI_ENV_VAR} (uid2-operator and skr), found ${RULE_COUNT}"
-    echo "The az confcom output format has likely changed and the env_rules sed no longer matches"
-    exit 1
-  fi
-done
-
-if ! grep -q "allow_environment_variable_dropping := false" ${INPUT_DIR}/generated.rego; then
-  echo "allow_environment_variable_dropping is not false in the generated policy"
-  exit 1
-fi
 base64 -w0 < ${INPUT_DIR}/generated.rego > ${INPUT_DIR}/generated.rego.base64
 python3 ${SCRIPT_DIR}/generate.py ${INPUT_DIR}/generated.rego > ${MANIFEST_DIR}/${POLICY_DIGEST_FILE}
 


### PR DESCRIPTION
Reverts #2720. Confirmed with Microsoft: the denied container is fragment-defined, so our env_rules are never consulted regardless of pattern. Superseded by #2734.

Ticket: UID2-7804