### PR TITLE
UID2-7849 UID2-7850: Suppress libexpat CVEs, upgrade netty-handler

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -53,3 +53,11 @@ CVE-2026-66046 exp:2026-12-02
 # binding; runs java -jar
 # See: UID2-7801
 CVE-2026-76641 exp:2026-12-02
+
+# libexpat is an Alpine OS package; this is a Java/Vert.x service that parses XML via JAXP/Xerces, not libexpat — no native/JNI path reaches it
+# See: UID2-7849
+CVE-2026-76956 exp:2026-10-10
+
+# libexpat is an Alpine OS package; this is a Java/Vert.x service that parses XML via JAXP/Xerces, not libexpat — no native/JNI path reaches it
+# See: UID2-7849
+CVE-2026-76957 exp:2026-10-10

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <java.version>21</java.version>
-        <netty.version>4.1.136.Final</netty.version>
+        <netty.version>4.1.137.Final</netty.version>
         <jackson.version>2.21.4</jackson.version>
     </properties>
 


### PR DESCRIPTION
## Summary

- **UID2-7849** — [CVE-2026-76956](https://thetradedesk.atlassian.net/browse/UID2-7849) and [CVE-2026-76957](https://thetradedesk.atlassian.net/browse/UID2-7849) (libexpat, Alpine OS package, HIGH): suppressed in `.trivyignore`, not fixed. libexpat is a native C library in the Alpine base image; this is a pure Java/Vert.x service that parses XML via JAXP/Xerces, so no native/JNI path reaches libexpat. Follows the same reasoning already recorded in this file for the prior libexpat CVEs (UID2-7800, UID2-7801).
- **UID2-7850** — [CVE-2026-75595](https://thetradedesk.atlassian.net/browse/UID2-7850) (`io.netty:netty-handler`, CRITICAL, installed 4.1.136.Final): real fix. Bumped `netty.version` to `4.1.137.Final` in `pom.xml`, which flows through the `netty-bom` import to `netty-handler` and every other Netty artifact. This service runs Vert.x (built on Netty) as its live HTTP server, so the vulnerable code path is genuinely reachable.

There is a single `.trivyignore` at the repo root shared by all three Dockerfile image scans (`./Dockerfile`, `scripts/azure-cc/Dockerfile`, `scripts/gcp-oidc/Dockerfile`) — all three build the same Maven jar on the same Alpine base and reported identical findings, so one `.trivyignore` update and one `pom.xml` version bump cover all three images.

## Test plan

- `mvn dependency:tree -Dincludes=io.netty` confirms every `io.netty:*` artifact (including `netty-handler`) resolves to `4.1.137.Final`.
- `mvn compile` succeeds.
- `mvn test` — full suite passes: 761 tests, 0 failures, 0 errors.